### PR TITLE
[FEAT] make join & login & error api response

### DIFF
--- a/gotbetter/.gitignore
+++ b/gotbetter/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+application-security.properties

--- a/gotbetter/build.gradle
+++ b/gotbetter/build.gradle
@@ -24,6 +24,24 @@ dependencies {
 	implementation 'org.springframework.kafka:spring-kafka'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-devtools'
+	runtimeOnly 'mysql:mysql-connector-java'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+	// jwt 사용
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/gotbetter/src/main/java/pcrc/gotbetter/setting/QuerydslConfig.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/setting/QuerydslConfig.java
@@ -1,0 +1,18 @@
+package pcrc.gotbetter.setting;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/setting/http_api/ApiErrorView.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/setting/http_api/ApiErrorView.java
@@ -1,0 +1,57 @@
+package pcrc.gotbetter.setting.http_api;
+
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.util.ObjectUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@ToString
+public class ApiErrorView {
+    private final List<Error> errors;
+
+    public ApiErrorView(List<MessageType> messageTypes) {
+        this.errors = messageTypes.stream().map(Error::errorWithMessageType).collect(Collectors.toList());
+    }
+
+    public ApiErrorView(GetBetterException exception) {
+        this.errors = Collections.singletonList(Error.errorWithException(exception));
+    }
+
+    public ApiErrorView(MessageType messageType, String message) {
+        this.errors = Collections.singletonList(Error.errorWithMessageTypeAndMessage(messageType, message));
+    }
+
+    @Getter
+    @ToString
+    public static class Error {
+        private final String errorType;
+        private final String errorMessage;
+
+        public static Error errorWithMessageType(MessageType messageType) {
+            return new Error(messageType.name(), messageType.getMessage());
+        }
+
+        public static Error errorWithMessageTypeAndMessage(MessageType messageType, String message) {
+            return new Error(messageType.name(), message);
+        }
+
+        public static Error errorWithException(GetBetterException getBetterException) {
+            return new Error(getBetterException);
+        }
+
+        private Error(String errorType, String errorMessage) {
+            this.errorType = errorType;
+            this.errorMessage = errorMessage;
+        }
+
+        private Error(GetBetterException getBetterException) {
+            this.errorType = ObjectUtils.isEmpty(getBetterException.getType()) ? getBetterException.getStatus().getReasonPhrase() :
+                    getBetterException.getType();
+            this.errorMessage = getBetterException.getMessage();
+        }
+    }
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/setting/http_api/ApiExceptionHandler.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/setting/http_api/ApiExceptionHandler.java
@@ -1,0 +1,87 @@
+package pcrc.gotbetter.setting.http_api;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.connector.ClientAbortException;
+import org.springframework.beans.TypeMismatchException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.lang.Nullable;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.Collections;
+
+@Slf4j
+@RestControllerAdvice
+public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(ClientAbortException.class)
+    public ResponseEntity<?> clientAbortException() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-Type", "application/json");
+        return new ResponseEntity<>(new ApiErrorView(Collections.singletonList(MessageType.INTERNAL_SERVER_ERROR)),
+                headers,
+                HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(GetBetterException.class)
+    public ResponseEntity<?> opMessageException(GetBetterException getBetterException) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-Type", "application/json");
+        return new ResponseEntity<>(new ApiErrorView(getBetterException),
+                headers,
+                getBetterException.getStatus());
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        return new ResponseEntity<>(new ApiErrorView(MessageType.BAD_REQUEST, ex.getMessage()), status);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(
+            HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return new ResponseEntity<>(new ApiErrorView(MessageType.INTERNAL_SERVER_ERROR, ex.getMessage()), status);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleTypeMismatch(
+            TypeMismatchException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return new ResponseEntity<>(new ApiErrorView(MessageType.INTERNAL_SERVER_ERROR, ex.getMessage()), status);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(
+            HttpRequestMethodNotSupportedException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return new ResponseEntity<>(new ApiErrorView(MessageType.INTERNAL_SERVER_ERROR, ex.getMessage()), status);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMissingServletRequestParameter(
+            MissingServletRequestParameterException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return new ResponseEntity<>(new ApiErrorView(MessageType.INTERNAL_SERVER_ERROR, ex.getMessage()), status);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMediaTypeNotAcceptable(
+            HttpMediaTypeNotAcceptableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return new ResponseEntity<>(new ApiErrorView(MessageType.INTERNAL_SERVER_ERROR, ex.getMessage()), status);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(
+            Exception ex, @Nullable Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+        return new ResponseEntity<>(new ApiErrorView(MessageType.INTERNAL_SERVER_ERROR, ex.getMessage()), statusCode);
+    }
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/setting/http_api/GetBetterException.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/setting/http_api/GetBetterException.java
@@ -1,0 +1,16 @@
+package pcrc.gotbetter.setting.http_api;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class GetBetterException extends RuntimeException {
+    private final HttpStatus status;
+    private final String type;
+
+    public GetBetterException(MessageType messageType) {
+        super(messageType.getMessage());
+        this.status = messageType.getStatus(); //ex) 404
+        this.type = messageType.name(); //ex) NOT_FOUND
+    }
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/setting/http_api/MessageType.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/setting/http_api/MessageType.java
@@ -1,0 +1,22 @@
+package pcrc.gotbetter.setting.http_api;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum MessageType {
+    BAD_REQUEST ("Check API request URL protocol, parameter, etc. for errors", HttpStatus.BAD_REQUEST),
+    NOT_FOUND ("No data was found for the server. Please refer to parameter description.", HttpStatus.NOT_FOUND),
+    INTERNAL_SERVER_ERROR ("An error occurred inside the server.", HttpStatus.INTERNAL_SERVER_ERROR),
+    CONFLICT ("Already exists data.", HttpStatus.CONFLICT)
+    ;
+
+    private final String message;
+    private final HttpStatus status;
+
+    MessageType(String message, HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/setting/security/JWT/JwtProvider.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/setting/security/JWT/JwtProvider.java
@@ -1,0 +1,61 @@
+package pcrc.gotbetter.setting.security.JWT;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class JwtProvider {
+    private final Key secretKey;
+    private final Long accessExpiredTime;
+    private final Long refreshExpiredTime;
+
+    public JwtProvider(@Value("${external.jwt.secretKey}") String secretKey,
+                       @Value("${external.jwt.accessTokenExpiredTime}") Long accessExpiredTime,
+                       @Value("${external.jwt.refreshTokenExpiredTime}") Long refreshExpiredTime) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+        this.accessExpiredTime = accessExpiredTime;
+        this.refreshExpiredTime = refreshExpiredTime;
+    }
+
+    public TokenInfo generateToken(String auth_id) {
+
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("type", "token");
+
+        Map<String, Object> payloads = new HashMap<>();
+        payloads.put("id", auth_id);
+
+        Date now = new Date();
+
+        //Access Token 생성
+        String accessToken = Jwts.builder()
+                .setHeader(headers)
+                .setClaims(payloads)
+                .setSubject("got-better")
+                .setExpiration(new Date(now.getTime() + accessExpiredTime))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+
+        //Refresh Token 생성
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now.getTime() + refreshExpiredTime))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+
+        return TokenInfo.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/setting/security/JWT/TokenInfo.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/setting/security/JWT/TokenInfo.java
@@ -1,0 +1,15 @@
+package pcrc.gotbetter.setting.security.JWT;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class TokenInfo {
+
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/setting/security/SecurityConfig.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/setting/security/SecurityConfig.java
@@ -1,0 +1,83 @@
+package pcrc.gotbetter.setting.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Value("${external.frontend}")
+    private String frontend;
+    @Value("${external.backend}")
+    private String backend;
+    @Value("${external.localFront}")
+    private String localFront;
+    @Value("${external.localBack}")
+    private String localBack;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        String[] uri = {"/users/join", "/users", "/users/join/verify"};
+
+        http.cors().configurationSource(corsConfigurationSource());
+        http.httpBasic().disable()
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        http.authorizeHttpRequests()
+                .requestMatchers(HttpMethod.POST, uri).permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .formLogin().disable()
+                .rememberMe().disable()
+                .logout().disable();
+//                .and();
+//                .exceptionHandling()
+//                .accessDeniedHandler(webAccessDeniedHandler)
+//                .authenticationEntryPoint(authenticationEntryPointHandler)
+//                .and()
+//                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.addAllowedOrigin(frontend);
+        configuration.addAllowedOrigin(backend);
+        configuration.addAllowedOrigin(localFront);
+        configuration.addAllowedOrigin(localBack);
+        configuration.addAllowedHeader(localFront);
+        configuration.addAllowedHeader(frontend);
+        configuration.addAllowedOrigin("http://jxy.me");
+        configuration.addAllowedHeader("http://jxy.me");
+        configuration.addAllowedMethod("POST");
+        configuration.addAllowedMethod("GET");
+        configuration.addAllowedMethod("PUT");
+        configuration.addAllowedMethod("DELETE");
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/domain/User.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/domain/User.java
@@ -1,0 +1,33 @@
+package pcrc.gotbetter.user.data_access.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+
+@Entity
+@Table(name = "User")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicInsert
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+    @Column(name = "auth_id")
+    private String authId;
+    private String password;
+    private String username;
+    private String email;
+    private String profile;
+    private String refresh_token;
+
+    @Builder
+    public User(String authId, String password, String username, String email, String profile) {
+        this.authId = authId;
+        this.password = password;
+        this.username = username;
+        this.email = email;
+        this.profile = profile;
+    }
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package pcrc.gotbetter.user.data_access.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pcrc.gotbetter.user.data_access.domain.User;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Integer>, UserRepositoryQueryDSL {
+    Optional<User> findByAuthId(String auth_id);
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserRepositoryQueryDSL.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserRepositoryQueryDSL.java
@@ -1,0 +1,6 @@
+package pcrc.gotbetter.user.data_access.repository;
+
+public interface UserRepositoryQueryDSL {
+    Boolean existsByAuthidOrEmail(String auth_id, String email);
+    void updateRefreshToken(String auth_id, String refresh_token);
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserRepositoryQueryDSLImpl.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserRepositoryQueryDSLImpl.java
@@ -1,0 +1,57 @@
+package pcrc.gotbetter.user.data_access.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.util.StringUtils;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import static pcrc.gotbetter.user.data_access.domain.QUser.user;
+
+public class UserRepositoryQueryDSLImpl implements UserRepositoryQueryDSL {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Autowired
+    public UserRepositoryQueryDSLImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public Boolean existsByAuthidOrEmail(String auth_id, String email) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.or(eqAuthId(auth_id))
+                .or(eqEmail(email));
+        Integer existsUser = queryFactory
+                .selectOne()
+                .from(user)
+                .where(builder)
+                .fetchFirst();
+        return existsUser != null;
+    }
+
+    @Override
+    @Transactional
+    public void updateRefreshToken(String auth_id, String refresh_token) {
+        queryFactory
+                .update(user)
+                .where(eqAuthId(auth_id))
+                .set(user.refresh_token, refresh_token)
+                .execute();
+    }
+
+    private BooleanExpression eqAuthId(String auth_id) {
+        if (StringUtils.isNullOrEmpty(auth_id)) {
+            return null;
+        }
+        return user.authId.eq(auth_id);
+    }
+
+    private BooleanExpression eqEmail(String email) {
+        if (StringUtils.isNullOrEmpty(email)) {
+            return null;
+        }
+        return user.email.eq(email);
+    }
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/service/UserOperationUseCase.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/service/UserOperationUseCase.java
@@ -1,0 +1,20 @@
+package pcrc.gotbetter.user.service;
+
+import lombok.*;
+
+public interface UserOperationUseCase {
+
+    UserReadUseCase.FindUserResult createUser(UserCreateCommand command);
+
+    @EqualsAndHashCode(callSuper = false)
+    @Builder
+    @Getter
+    @ToString
+    class UserCreateCommand {
+        private final String auth_id;
+        private final String password;
+        private final String username;
+        private final String email;
+    }
+
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/service/UserReadUseCase.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/service/UserReadUseCase.java
@@ -1,0 +1,46 @@
+package pcrc.gotbetter.user.service;
+
+import lombok.*;
+import pcrc.gotbetter.setting.security.JWT.TokenInfo;
+import pcrc.gotbetter.user.data_access.domain.User;
+
+import java.io.IOException;
+
+public interface UserReadUseCase {
+
+    FindUserResult loginUser(UserFindQuery query) throws IOException;
+    FindUserResult verifyId(String auth_id);
+
+    @EqualsAndHashCode(callSuper = false)
+    @Getter
+    @ToString
+    @Builder
+    class UserFindQuery {
+        private final String auth_id;
+        private final String password;
+    }
+
+    @Getter
+    @ToString
+    @Builder
+    class FindUserResult {
+        private final String auth_id;
+        private final String username;
+        private final String email;
+        private final String profile;
+        private final String access_token;
+        private final String refresh_token;
+
+        public static FindUserResult findByUser(User user, TokenInfo tokenInfo) {
+            return FindUserResult.builder()
+                    .auth_id(user.getAuthId())
+                    .username(user.getUsername())
+                    .email(user.getEmail())
+                    .profile(user.getProfile())
+                    .access_token(tokenInfo.getAccessToken())
+                    .refresh_token(tokenInfo.getRefreshToken())
+                    .build();
+        }
+    }
+
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/service/UserService.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/service/UserService.java
@@ -1,0 +1,103 @@
+package pcrc.gotbetter.user.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import pcrc.gotbetter.setting.http_api.GetBetterException;
+import pcrc.gotbetter.setting.http_api.MessageType;
+import pcrc.gotbetter.setting.security.JWT.JwtProvider;
+import pcrc.gotbetter.setting.security.JWT.TokenInfo;
+import pcrc.gotbetter.user.data_access.domain.User;
+import pcrc.gotbetter.user.data_access.repository.UserRepository;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
+
+@Service
+public class UserService implements UserOperationUseCase, UserReadUseCase {
+
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+
+    @Autowired
+    public UserService(PasswordEncoder passwordEncoder, UserRepository userRepository,
+                       JwtProvider jwtProvider) {
+        this.passwordEncoder = passwordEncoder;
+        this.userRepository = userRepository;
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Override
+    public FindUserResult createUser(UserCreateCommand command) {
+        validateDuplicateUser(command.getAuth_id(), command.getEmail());
+        String encodePassword = passwordEncoder.encode(command.getPassword());
+        User saveUser = User.builder()
+                .authId(command.getAuth_id())
+                .password(encodePassword)
+                .username(command.getUsername())
+                .email(command.getEmail())
+                .build();
+        userRepository.save(saveUser);
+        return FindUserResult.findByUser(saveUser, TokenInfo.builder().build());
+    }
+
+    @Override
+    public FindUserResult verifyId(String auth_id) {
+        validateDuplicateUser(auth_id, null);
+        User user = User.builder()
+                .authId(auth_id)
+                .build();
+        return FindUserResult.findByUser(user, TokenInfo.builder().build());
+    }
+
+    @Override
+    public FindUserResult loginUser(UserFindQuery query) throws IOException {
+        // 아이디와 비번이 매치되는 유저가 있는지 확인
+        User findUser = validateFindUser(query);
+
+        // profile
+        String default_profile = "/home/chaerin/gotbetter/image/profile/default_profile/default_profile.jpg";
+        String bytes = null;
+        try {
+            bytes = Base64.getEncoder().encodeToString(Files.readAllBytes(
+                    Paths.get(findUser.getProfile())));
+        } catch (Exception e) {
+            bytes = Base64.getEncoder().encodeToString(Files.readAllBytes(Paths.get(default_profile)));
+        }
+
+        // jwt
+        TokenInfo tokenInfo = jwtProvider.generateToken(findUser.getAuthId());
+        userRepository.updateRefreshToken(findUser.getAuthId(), tokenInfo.getRefreshToken());
+
+        User user = User.builder()
+                .authId(findUser.getAuthId())
+                .username(findUser.getUsername())
+                .email(findUser.getEmail())
+                .profile(bytes)
+                .build();
+        return FindUserResult.findByUser(user, tokenInfo);
+    }
+
+    private void validateDuplicateUser(String auth_id, String email) {
+        // 이미 있는 아이디인지 또는 이미 있는 이메일인지 확인
+        if (userRepository.existsByAuthidOrEmail(auth_id, email)) {
+            throw new GetBetterException(MessageType.CONFLICT);
+        }
+    }
+
+    private User validateFindUser(UserFindQuery query) {
+        User findUser = userRepository.findByAuthId(query.getAuth_id())
+                .orElseThrow(() -> {
+                    throw new GetBetterException(MessageType.NOT_FOUND);
+                });
+
+        if (!passwordEncoder.matches(query.getPassword(), findUser.getPassword())) {
+            throw new GetBetterException(MessageType.NOT_FOUND);
+        }
+
+        return findUser;
+    }
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/ui/controller/UserController.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/ui/controller/UserController.java
@@ -1,0 +1,76 @@
+package pcrc.gotbetter.user.ui.controller;
+
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import pcrc.gotbetter.user.service.UserReadUseCase;
+import pcrc.gotbetter.user.ui.requestBody.UserJoinRequest;
+import pcrc.gotbetter.user.service.UserOperationUseCase;
+import pcrc.gotbetter.user.ui.requestBody.UserLoginRequest;
+import pcrc.gotbetter.user.ui.requestBody.UserVerifyIdRequest;
+import pcrc.gotbetter.user.ui.view.UserJoinView;
+import pcrc.gotbetter.user.ui.view.UserLoginView;
+import pcrc.gotbetter.user.ui.view.UserVerifyIdView;
+
+import java.io.IOException;
+
+@Slf4j
+@RestController
+@RequestMapping(value = "/users")
+public class UserController {
+
+    private final UserOperationUseCase userOperationUseCase;
+    private final UserReadUseCase userReadUseCase;
+
+    @Autowired
+    public UserController(UserOperationUseCase userOperationUseCase,
+                          UserReadUseCase userReadUseCase) {
+        this.userOperationUseCase = userOperationUseCase;
+        this.userReadUseCase = userReadUseCase;
+    }
+
+    @PostMapping(value = "/join")
+    public ResponseEntity<UserJoinView> newUserJoin(@Valid @RequestBody UserJoinRequest request) {
+
+        log.info("\"JOIN\"");
+
+        var command = UserOperationUseCase.UserCreateCommand.builder()
+                .auth_id(request.getAuth_id())
+                .password(request.getPassword())
+                .username(request.getUsername())
+                .email(request.getEmail())
+                .build();
+        UserReadUseCase.FindUserResult result = userOperationUseCase.createUser(command);
+
+        return ResponseEntity.created(null).body(UserJoinView.builder().userResult(result).build());
+    }
+
+    @PostMapping(value = "/join/verify")
+    public ResponseEntity<UserVerifyIdView> verifyId(@Valid @RequestBody UserVerifyIdRequest request) {
+
+        log.info("\"VERIFY ID\"");
+
+        UserReadUseCase.FindUserResult result = userReadUseCase.verifyId(request.getAuth_id());
+
+        return ResponseEntity.ok(UserVerifyIdView.builder().userResult(result).build());
+    }
+
+    @PostMapping(value = "")
+    public ResponseEntity<UserLoginView> login(@Valid @RequestBody UserLoginRequest request) throws IOException {
+
+        log.info("\"LOGIN\"");
+
+        var query = UserReadUseCase.UserFindQuery.builder()
+                .auth_id(request.getAuth_id())
+                .password(request.getPassword())
+                .build();
+        UserReadUseCase.FindUserResult result = userReadUseCase.loginUser(query);
+
+        return ResponseEntity.ok(UserLoginView.builder().userResult(result).build());
+    }
+
+    @PostMapping(value = "/refresh")
+    public void refreshToken() {}
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/ui/requestBody/UserJoinRequest.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/ui/requestBody/UserJoinRequest.java
@@ -1,0 +1,22 @@
+package pcrc.gotbetter.user.ui.requestBody;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class UserJoinRequest {
+
+    @NotNull @NotBlank
+    private String auth_id;
+    @NotNull @NotBlank
+    private String password;
+    @NotNull @NotBlank
+    private String username;
+    @NotNull @NotBlank @Email
+    private String email;
+
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/ui/requestBody/UserLoginRequest.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/ui/requestBody/UserLoginRequest.java
@@ -1,0 +1,18 @@
+package pcrc.gotbetter.user.ui.requestBody;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class UserLoginRequest {
+
+    @NotNull @NotBlank
+    private String auth_id;
+    @NotNull @NotBlank
+    private String password;
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/ui/requestBody/UserVerifyIdRequest.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/ui/requestBody/UserVerifyIdRequest.java
@@ -1,0 +1,16 @@
+package pcrc.gotbetter.user.ui.requestBody;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class UserVerifyIdRequest {
+
+    @NotNull @NotBlank
+    private String auth_id;
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/ui/view/UserJoinView.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/ui/view/UserJoinView.java
@@ -1,0 +1,23 @@
+package pcrc.gotbetter.user.ui.view;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import pcrc.gotbetter.user.service.UserReadUseCase;
+
+@Getter
+@ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UserJoinView {
+    private final String auth_id;
+    private final String username;
+    private final String email;
+
+    @Builder
+    public UserJoinView(UserReadUseCase.FindUserResult userResult) {
+        this.auth_id = userResult.getAuth_id();
+        this.username = userResult.getUsername();
+        this.email = userResult.getEmail();
+    }
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/ui/view/UserLoginView.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/ui/view/UserLoginView.java
@@ -1,0 +1,29 @@
+package pcrc.gotbetter.user.ui.view;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import pcrc.gotbetter.user.service.UserReadUseCase;
+
+@Getter
+@ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UserLoginView {
+    private final String auth_id;
+    private final String username;
+    private final String email;
+    private final String profile;
+    private final String access_token;
+    private final String refresh_token;
+
+    @Builder
+    public UserLoginView(UserReadUseCase.FindUserResult userResult) {
+        this.auth_id = userResult.getAuth_id();
+        this.username = userResult.getUsername();
+        this.email = userResult.getEmail();
+        this.profile = userResult.getProfile();
+        this.access_token = userResult.getAccess_token();
+        this.refresh_token = userResult.getRefresh_token();
+    }
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/ui/view/UserVerifyIdView.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/ui/view/UserVerifyIdView.java
@@ -1,0 +1,19 @@
+package pcrc.gotbetter.user.ui.view;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import pcrc.gotbetter.user.service.UserReadUseCase;
+
+@Getter
+@ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UserVerifyIdView {
+    private final String auth_id;
+
+    @Builder
+    public UserVerifyIdView(UserReadUseCase.FindUserResult userResult) {
+        this.auth_id = userResult.getAuth_id();
+    }
+}

--- a/gotbetter/src/main/resources/application.properties
+++ b/gotbetter/src/main/resources/application.properties
@@ -1,1 +1,29 @@
+# setting in application-security.properties
+spring.profiles.active=security
 
+# DB
+#spring.datasource.url=
+#spring.datasource.driver-class-name=
+#spring.datasource.username=
+#spring.datasource.password=
+#spring.jpa.database=
+spring.jpa.hibernate.naming.physical-strategy = org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+spring.jpa.properties.hibernate.ddl-auto=none
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+logging.level.org.hibernate.SQL=debug
+logging.level.org.hibernate.type=trace
+
+# jwt
+external.jwt.secretKey=
+external.jwt.accessTokenExpiredTime=
+external.jwt.refreshTokenExpiredTime=
+
+# ip
+external.frontend=
+external.backend=
+external.localFront=
+external.localBack=
+
+# kafka
+#kafka.bootstrap-server=

--- a/gotbetter/src/test/java/pcrc/gotbetter/user/UserRepositoryTest.java
+++ b/gotbetter/src/test/java/pcrc/gotbetter/user/UserRepositoryTest.java
@@ -1,0 +1,41 @@
+package pcrc.gotbetter.user;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+import pcrc.gotbetter.user.data_access.domain.User;
+import pcrc.gotbetter.user.data_access.repository.UserRepositoryQueryDSLImpl;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class UserRepositoryTest {
+
+    @Autowired
+    UserRepositoryQueryDSLImpl userRepositoryQueryDSLImpl;
+
+    @Test
+    @Transactional // 테스트 끝나고 바로 롤백해버림
+//    @Rollback(value = false)
+    public void testUser() throws Exception {
+        //given
+//        User user = new User();
+//        user.setAuth_id("geulyeogeulyeo2");
+//        user.setPassword("aa");
+//        user.setUsername("짱구");
+//        user.setEmail("jjang-gu2@gmail.com");
+//        user.setProfile("??");
+
+        //when
+//        Integer saveId = userRepositoryQueryDSLImpl.save(user);
+//        User findUser = userRepositoryQueryDSLImpl.findOne(saveId);
+
+        //then
+//        Assertions.assertThat(findUser.getId()).isEqualTo(user.getId());
+//        Assertions.assertThat(findUser.getAuth_id()).isEqualTo(user.getAuth_id());
+
+    }
+}


### PR DESCRIPTION
### 회원가입

- 가입에 필요한 데이터를 포함한 요청을 받아 회원 생성

- **로그인 중복 확인**을 통해 중복되는 아이디가 있는지 확인

### 로그인

- 아이디와 비밀번호에 매칭하는 회원이 있는지 확인 후 회원 정보 전달

### 에러 API Response

- 요청에 대하여 원하는 HTTP 상태코드와 메시지가 응답되도록 구현


**관련 이슈**
* #6 
* #7 
* #4 