### PR TITLE
[refactor] User 도메인의 spring data jpa과 querydsl 역할을 확실하게 구분

### DIFF
--- a/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/entity/User.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/entity/User.java
@@ -3,6 +3,7 @@ package pcrc.gotbetter.user.data_access.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
 import pcrc.gotbetter.setting.BaseTimeEntity;
 import pcrc.gotbetter.user.login_method.login_type.RoleType;
@@ -12,6 +13,7 @@ import pcrc.gotbetter.user.login_method.login_type.RoleType;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
+@DynamicUpdate
 public class User extends BaseTimeEntity {
 
     @Id
@@ -40,11 +42,22 @@ public class User extends BaseTimeEntity {
     @Builder
     public User(Long userId, String username,
                 String email, String profile,
-                RoleType roleType) {
+                RoleType roleType, String refreshToken,
+                String fcmToken) {
         this.userId = userId;
         this.username = username;
         this.email = email;
         this.profile = profile;
         this.roleType = roleType;
+        this.refreshToken = refreshToken;
+        this.fcmToken = fcmToken;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void updateUsername(String username) {
+        this.username = username;
     }
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserRepository.java
@@ -8,5 +8,9 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryQueryDSL {
+
     Optional<User> findByUserId(Long userId);
+
+    User findByEmail(String email);
+
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserRepositoryImpl.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserRepositoryImpl.java
@@ -2,11 +2,9 @@ package pcrc.gotbetter.user.data_access.repository;
 
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
-import pcrc.gotbetter.user.data_access.entity.User;
 
 import static pcrc.gotbetter.user.data_access.entity.QUser.user;
 
@@ -35,39 +33,12 @@ public class UserRepositoryImpl implements UserRepositoryQueryDSL {
 
     @Override
     @Transactional
-    public void updateUsername(Long userId, String username) {
-        queryFactory
-                .update(user)
-                .where(eqUserId(userId))
-                .set(user.username, username)
-                .execute();
-    }
-
-    @Override
-    @Transactional
     public void updateFcmToken(Long userId, String fcmToken) {
         queryFactory
             .update(user)
             .where(eqUserId(userId))
             .set(user.fcmToken, fcmToken)
             .execute();
-    }
-
-    @Override
-    public Long findUserIdByEmail(String email) {
-        return queryFactory
-                .select(user.userId)
-                .from(user)
-                .where(eqEmail(email))
-                .fetchFirst();
-    }
-
-    @Override
-    public User findByEmail(String email) {
-        return queryFactory
-                .selectFrom(user)
-                .where(eqEmail(email))
-                .fetchFirst();
     }
 
     @Override
@@ -91,12 +62,5 @@ public class UserRepositoryImpl implements UserRepositoryQueryDSL {
      */
     private BooleanExpression eqUserId(Long userId) {
         return userId == null ? null : user.userId.eq(userId);
-    }
-
-    private BooleanExpression eqEmail(String email) {
-        if (StringUtils.isNullOrEmpty(email)) {
-            return null;
-        }
-        return user.email.eq(email);
     }
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserRepositoryQueryDSL.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserRepositoryQueryDSL.java
@@ -3,16 +3,11 @@ package pcrc.gotbetter.user.data_access.repository;
 import java.util.HashMap;
 import java.util.List;
 
-import pcrc.gotbetter.user.data_access.entity.User;
-
 public interface UserRepositoryQueryDSL {
     // insert, update, delete
     void updateRefreshToken(Long userId, String refreshToken);
-    void updateUsername(Long userId, String username);
     void updateFcmToken(Long userId, String fcmToken);
 
     // select
-    Long findUserIdByEmail(String email);
-    User findByEmail(String email);
     HashMap<Long, List<String>> getAllUsersUserIdAndFcmToken();
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserSetRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserSetRepository.java
@@ -6,4 +6,9 @@ import pcrc.gotbetter.user.data_access.entity.UserSet;
 
 @Repository
 public interface UserSetRepository extends JpaRepository<UserSet, Long>, UserSetRepositoryQueryDSL {
+
+	UserSet findByAuthId(String authId);
+
+	UserSet findByUserId(Long userId);
+
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserSetRepositoryImpl.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserSetRepositoryImpl.java
@@ -4,7 +4,6 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import pcrc.gotbetter.user.data_access.entity.UserSet;
 
 import static pcrc.gotbetter.user.data_access.entity.QUserSet.userSet;
 
@@ -34,22 +33,6 @@ public class UserSetRepositoryImpl implements UserSetRepositoryQueryDSL {
                 .where(eqAuthId(authId))
                 .fetchFirst();
         return existsUser != null;
-    }
-
-    @Override
-    public UserSet findByUserId(Long userId) {
-        return queryFactory
-                .selectFrom(userSet)
-                .where(eqUserId(userId))
-                .fetchFirst();
-    }
-
-    @Override
-    public UserSet findByAuthId(String authId) {
-        return queryFactory
-                .selectFrom(userSet)
-                .where(eqAuthId(authId))
-                .fetchFirst();
     }
 
     @Override

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserSetRepositoryQueryDSL.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserSetRepositoryQueryDSL.java
@@ -1,14 +1,11 @@
 package pcrc.gotbetter.user.data_access.repository;
 
-import pcrc.gotbetter.user.data_access.entity.UserSet;
-
 public interface UserSetRepositoryQueryDSL {
-    // insert, update, delete
 
-    // select
     Boolean existsByUserId(Long userId);
+
     Boolean existsByAuthId(String authId);
-    UserSet findByUserId(Long userId);
-    UserSet findByAuthId(String authId);
+
     String findAuthIdByUserId(Long userId);
+
 }


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #115 
<br/>

## ⚙️ 변경 사항 

User 도메인의 spring data jpa과 querydsl 역할을 확실하게 구분

- querydsl에서 실행하던 update 쿼리를 spring data jpa에서 실행하도록 수정
- 간단한 쿼리는 spring data jpa에서 실행하고, 복잡하거나 exist 쿼리는 querydsl에서 실행하도록 수정

<br/>

## 💦 변경한 이유

- spring data jpa와 querydsl을 효율적으로 사용하고 있지 않았음.

<br/>

## 💻 테스트 사항

- 어떻게 테스트를 실행했는지 작성

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
