### PR TITLE
[refactor] User, UserSet, SocialAccount 도메인의 spring data jpa과 queryds…

### DIFF
--- a/gotbetter/src/main/java/pcrc/gotbetter/push_notification/service/FCMService.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/push_notification/service/FCMService.java
@@ -3,7 +3,6 @@ package pcrc.gotbetter.push_notification.service;
 import static pcrc.gotbetter.setting.security.SecurityUtil.*;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +22,9 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import pcrc.gotbetter.push_notification.FCMMessageDto;
+import pcrc.gotbetter.setting.http_api.GotBetterException;
+import pcrc.gotbetter.setting.http_api.MessageType;
+import pcrc.gotbetter.user.data_access.entity.User;
 import pcrc.gotbetter.user.data_access.repository.UserRepository;
 
 @Slf4j
@@ -44,7 +46,12 @@ public class FCMService implements FCMOperationUseCase {
 	@Override
 	public void storeToken(FCMStoreCommand command) {
 		Long currentUserId = getCurrentUserId();
-		userRepository.updateFcmToken(currentUserId, command.getFcmToken());
+		User findUser = userRepository.findByUserId(currentUserId).orElseThrow(() -> {
+			throw new GotBetterException(MessageType.NOT_FOUND);
+		});
+
+		findUser.updateFcmToken(command.getFcmToken());
+		userRepository.save(findUser);
 	}
 
 	@Override

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/entity/SocialAccount.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/entity/SocialAccount.java
@@ -1,12 +1,13 @@
 package pcrc.gotbetter.user.data_access.entity;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
 import pcrc.gotbetter.user.login_method.login_type.ProviderType;
 
 @Entity
@@ -14,23 +15,21 @@ import pcrc.gotbetter.user.login_method.login_type.ProviderType;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
+@DynamicUpdate
 public class SocialAccount {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "social_account_id")
+    @Column(name = "social_account_id", nullable = false)
     private Long socialAccountId;
 
-    @Column(name = "user_id")
-    @NotNull
+    @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "provider_type")
+    @Column(name = "provider_type", nullable = false)
     @Enumerated(EnumType.STRING)
-    @NotNull
     private ProviderType providerType;
 
-    @Column(name = "provider_id")
-    @NotNull
+    @Column(name = "provider_id", nullable = false)
     private String providerId;
 
     @Builder

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/entity/User.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/entity/User.java
@@ -60,4 +60,8 @@ public class User extends BaseTimeEntity {
     public void updateUsername(String username) {
         this.username = username;
     }
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
+    }
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/entity/UserSet.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/entity/UserSet.java
@@ -4,29 +4,28 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Table(name = "UserSet")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
+@DynamicUpdate
 public class UserSet {
     @Id
-    @Column(name = "user_id")
-    @NotNull
+    @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "auth_id")
-    @NotNull
+    @Column(name = "auth_id", nullable = false)
     private String authId;
 
-    @NotNull
+    @Column(nullable = false)
     private String password;
 
     @Builder

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/SocialAccountRepositoryImpl.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/SocialAccountRepositoryImpl.java
@@ -4,6 +4,8 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import pcrc.gotbetter.user.data_access.entity.SocialAccount;
 import pcrc.gotbetter.user.login_method.login_type.ProviderType;
 
 import static pcrc.gotbetter.user.data_access.entity.QSocialAccount.socialAccount;
@@ -17,16 +19,17 @@ public class SocialAccountRepositoryImpl implements SocialAccountRepositoryQuery
     }
 
     @Override
-    public Boolean existsByProviderTypeAndProviderId(ProviderType providerType, String providerId) {
-        Integer existsUser = queryFactory
-                .selectOne()
-                .from(socialAccount)
-                .where(eqProviderType(providerType),
-                        eqProviderId(providerId))
-                .fetchFirst();
-        return existsUser != null;
+    public SocialAccount findByTypeAndId(ProviderType providerType, String providerId) {
+        return queryFactory
+            .selectFrom(socialAccount)
+            .where(eqProviderType(providerType),
+                eqProviderId(providerId))
+            .fetchFirst();
     }
 
+    /**
+     * eq
+     */
     private BooleanExpression eqProviderType(ProviderType provider_type) {
         if (StringUtils.isNullOrEmpty(String.valueOf(provider_type))) {
             return null;

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/SocialAccountRepositoryQueryDSL.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/SocialAccountRepositoryQueryDSL.java
@@ -1,10 +1,10 @@
 package pcrc.gotbetter.user.data_access.repository;
 
+import pcrc.gotbetter.user.data_access.entity.SocialAccount;
 import pcrc.gotbetter.user.login_method.login_type.ProviderType;
 
 public interface SocialAccountRepositoryQueryDSL {
-    // create, update, delete
 
-    // select
-    Boolean existsByProviderTypeAndProviderId(ProviderType providerType, String providerId);
+    SocialAccount findByTypeAndId(ProviderType providerType, String providerId);
+
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserRepositoryImpl.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserRepositoryImpl.java
@@ -4,7 +4,6 @@ import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 import static pcrc.gotbetter.user.data_access.entity.QUser.user;
 
@@ -19,26 +18,6 @@ public class UserRepositoryImpl implements UserRepositoryQueryDSL {
     @Autowired
     public UserRepositoryImpl(JPAQueryFactory queryFactory) {
         this.queryFactory = queryFactory;
-    }
-
-    @Override
-    @Transactional
-    public void updateRefreshToken(Long userId, String refreshToken) {
-        queryFactory
-                .update(user)
-                .where(eqUserId(userId))
-                .set(user.refreshToken, refreshToken)
-                .execute();
-    }
-
-    @Override
-    @Transactional
-    public void updateFcmToken(Long userId, String fcmToken) {
-        queryFactory
-            .update(user)
-            .where(eqUserId(userId))
-            .set(user.fcmToken, fcmToken)
-            .execute();
     }
 
     @Override

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserRepositoryQueryDSL.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/data_access/repository/UserRepositoryQueryDSL.java
@@ -4,10 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 
 public interface UserRepositoryQueryDSL {
-    // insert, update, delete
-    void updateRefreshToken(Long userId, String refreshToken);
-    void updateFcmToken(Long userId, String fcmToken);
 
-    // select
     HashMap<Long, List<String>> getAllUsersUserIdAndFcmToken();
+
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/login_method/jwt/service/JwtService.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/login_method/jwt/service/JwtService.java
@@ -35,7 +35,8 @@ public class JwtService {
         long diffDays = compareDate(jwtProvider.parseClaims(refreshToken).getExpiration());
         TokenInfo tokenInfo = jwtProvider.generateToken(user.getUserId().toString());
         if (diffDays < 30) {
-            userRepository.updateRefreshToken(user.getUserId(), tokenInfo.getRefreshToken());
+            user.updateRefreshToken(tokenInfo.getRefreshToken());
+            userRepository.save(user);
         } else {
             tokenInfo.setRefreshToken(refreshToken);
         }


### PR DESCRIPTION
…l 역할을 확실하게 구분

## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #118 
<br/>

## ⚙️ 변경 사항 

User, UserSet, SocialAccount 도메인의 spring data jpa과 querydsl 역할을 확실하게 구분

- querydsl에서 실행하던 update 쿼리를 spring data jpa에서 실행하도록 수정
- 간단한 쿼리는 spring data jpa에서 실행하고, 복잡하거나 exist 쿼리는 querydsl에서 실행하도록 수정

<br/>

## 💦 변경한 이유

- spring data jpa와 querydsl을 비효율적으로 사용하고 있었음.
- jpa의 캐시 기능을 고려하지 않고 querydsl로 CRUD 쿼리를 실행함.

<br/>

## 💻 테스트 사항

- postman으로 테스트 진행

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
