### PR TITLE
[feat] Room 도메인의 spring data jpa과 querydsl 역할을 확실하게 구분

### DIFF
--- a/gotbetter/src/main/java/pcrc/gotbetter/common/data_access/repository/CommonCodeRepositoryImpl.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/common/data_access/repository/CommonCodeRepositoryImpl.java
@@ -38,14 +38,6 @@ public class CommonCodeRepositoryImpl implements CommonCodeRepositoryQueryDSL {
     /**
      * eq
      */
-    private BooleanExpression eqCommonCodeId(CommonCodeId commonCodeId) {
-        if (StringUtils.isNullOrEmpty(String.valueOf(commonCodeId.getGroupCode()))
-                || StringUtils.isNullOrEmpty(String.valueOf(commonCodeId.getCode()))) {
-            return null;
-        }
-        return commonCode.commonCodeId.eq(commonCodeId);
-    }
-
     private BooleanExpression eqGroupCode(String groupCode) {
         if (StringUtils.isNullOrEmpty(String.valueOf(groupCode))) {
             return null;

--- a/gotbetter/src/main/java/pcrc/gotbetter/common/data_access/repository/CommonCodeRepositoryQueryDSL.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/common/data_access/repository/CommonCodeRepositoryQueryDSL.java
@@ -6,7 +6,9 @@ import pcrc.gotbetter.common.data_access.entity.CommonCodeId;
 import java.util.List;
 
 public interface CommonCodeRepositoryQueryDSL {
-    // select
+
     CommonCode findByCommonCodeId(CommonCodeId commonCodeId);
+
     List<CommonCode> findListByGroupCode(String groupCode);
+
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/service/ParticipantService.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/service/ParticipantService.java
@@ -111,7 +111,12 @@ public class ParticipantService implements ParticipantOperationUseCase, Particip
                 .build();
         participantRepository.save(participant);
         participantRepository.updateParticipateAccepted(targetUserInfo.getTryEnterId().getUserId(), targetUserInfo.getTryEnterId().getRoomId());
-        roomRepository.updatePlusTotalEntryFeeAndCurrentNum(command.getRoomId(), targetUserInfo.getEntryFee());
+        // 방 정보 중 totalEntryFee와 currentUserNum 업데이트
+        Room roomInfo = roomRepository.findByRoomId(command.getRoomId()).orElseThrow(() -> {
+            throw new GotBetterException(MessageType.NOT_FOUND);
+        });
+        roomInfo.updateTotalEntryFeeAndCurrentUserNum(targetUserInfo.getEntryFee());
+        roomRepository.save(roomInfo);
         String authId = validateUserSetAuthId(targetUserInfo.getTryEnterId().getUserId());
         return FindParticipantResult.findByParticipant(targetUserInfo,
                 participant.getParticipantId(), null, authId);

--- a/gotbetter/src/main/java/pcrc/gotbetter/room/data_access/entity/Room.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/room/data_access/entity/Room.java
@@ -65,4 +65,13 @@ public class Room extends BaseTimeEntity {
         this.totalEntryFee = totalEntryFee;
         this.rule = rule;
     }
+
+    public void updateCurrentWeekToNext() {
+        this.currentWeek += 1;
+    }
+
+    public void updateTotalEntryFeeAndCurrentUserNum(Integer fee) {
+        this.totalEntryFee += fee;
+        this.currentUserNum += 1;
+    }
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/room/data_access/repository/RoomRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/room/data_access/repository/RoomRepository.java
@@ -8,6 +8,9 @@ import java.util.Optional;
 
 @Repository
 public interface RoomRepository extends JpaRepository<Room, Long>, RoomRepositoryQueryDSL {
+
     Optional<Room> findByRoomCode(String roomCode);
+
     Optional<Room> findByRoomId(Long roomId);
+
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/room/data_access/repository/RoomRepositoryImpl.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/room/data_access/repository/RoomRepositoryImpl.java
@@ -4,7 +4,6 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 import pcrc.gotbetter.room.data_access.entity.Room;
 
 import java.util.List;
@@ -18,27 +17,6 @@ public class RoomRepositoryImpl implements RoomRepositoryQueryDSL{
     @Autowired
     public RoomRepositoryImpl(JPAQueryFactory queryFactory) {
         this.queryFactory = queryFactory;
-    }
-
-    @Override
-    @Transactional
-    public void updatePlusTotalEntryFeeAndCurrentNum(Long roomId, Integer fee) {
-        queryFactory
-                .update(room)
-                .set(room.totalEntryFee, room.totalEntryFee.add(fee))
-                .set(room.currentUserNum, room.currentUserNum.add(1))
-                .where(roomEqRoomId(roomId))
-                .execute();
-    }
-
-    @Override
-    @Transactional
-    public void updateCurrentWeek(Long roomId, Integer changeWeek) {
-        queryFactory
-                .update(room)
-                .set(room.currentWeek, changeWeek)
-                .where(roomEqRoomId(roomId))
-                .execute();
     }
 
     @Override

--- a/gotbetter/src/main/java/pcrc/gotbetter/room/data_access/repository/RoomRepositoryQueryDSL.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/room/data_access/repository/RoomRepositoryQueryDSL.java
@@ -5,13 +5,13 @@ import pcrc.gotbetter.room.data_access.entity.Room;
 import java.util.List;
 
 public interface RoomRepositoryQueryDSL {
-    // insert, update, delete
-    void updatePlusTotalEntryFeeAndCurrentNum(Long roomId, Integer fee);
-    void updateCurrentWeek(Long roomId, Integer changeWeek);
 
-    // select
     List<Room> findListUnderWeek();
+
     List<Room> findListLastWeek();
+
     Integer findCurrentWeek(Long roomId);
+
     Boolean existByRoomCode(String roomCode);
+
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/room/service/RoomReadUseCase.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/room/service/RoomReadUseCase.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface RoomReadUseCase {
 
-    List<FindRoomResult> getUserRooms();
+    List<FindRoomResult> getUserRoomList();
     FindRoomResult getOneRoomInfo(Long roomId);
     List<FindRankResult> getRank(Long roomId);
 

--- a/gotbetter/src/main/java/pcrc/gotbetter/room/ui/controller/RoomController.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/room/ui/controller/RoomController.java
@@ -27,12 +27,34 @@ public class RoomController {
         this.roomReadUseCase = roomReadUseCase;
     }
 
+    @PostMapping(value = "")
+    public ResponseEntity<RoomView> createNewRoom(@Valid @RequestBody RoomCreateRequest request) {
+
+        log.info("\"CREATE A ROOM\"");
+
+        var command = RoomOperationUseCase.RoomCreateCommand.builder()
+            .title(request.getTitle())
+            .maxUserNum(request.getMax_user_num())
+            .startDate(request.getStart_date())
+            .week(request.getWeek())
+            .currentWeek(request.getCurrent_week())
+            .entryFee(request.getEntry_fee())
+            .ruleCode(request.getRule_code())
+            .account(request.getAccount())
+            .roomCategoryCode(request.getRoom_category_code())
+            .description(request.getDescription())
+            .build();
+        RoomReadUseCase.FindRoomResult result = roomOperationUseCase.createRoom(command);
+
+        return ResponseEntity.created(null).body(RoomView.builder().roomResult(result).build());
+    }
+
     @GetMapping(value = "")
     public ResponseEntity<List<RoomView>> showIncludedRooms() {
 
         log.info("\"GET USER'S ROOMS\"");
 
-        List<RoomReadUseCase.FindRoomResult> result = roomReadUseCase.getUserRooms();
+        List<RoomReadUseCase.FindRoomResult> result = roomReadUseCase.getUserRoomList();
 
         List<RoomView> roomViews = new ArrayList<>();
         for (RoomReadUseCase.FindRoomResult r : result) {
@@ -49,28 +71,6 @@ public class RoomController {
         RoomReadUseCase.FindRoomResult result = roomReadUseCase.getOneRoomInfo(room_id);
 
         return ResponseEntity.ok(RoomView.builder().roomResult(result).build());
-    }
-
-    @PostMapping(value = "")
-    public ResponseEntity<RoomView> createNewRoom(@Valid @RequestBody RoomCreateRequest request) {
-
-        log.info("\"CREATE A ROOM\"");
-
-        var command = RoomOperationUseCase.RoomCreateCommand.builder()
-                .title(request.getTitle())
-                .maxUserNum(request.getMax_user_num())
-                .startDate(request.getStart_date())
-                .week(request.getWeek())
-                .currentWeek(request.getCurrent_week())
-                .entryFee(request.getEntry_fee())
-                .ruleCode(request.getRule_code())
-                .account(request.getAccount())
-                .roomCategoryCode(request.getRoom_category_code())
-                .description(request.getDescription())
-                .build();
-        RoomReadUseCase.FindRoomResult result = roomOperationUseCase.createRoom(command);
-
-        return ResponseEntity.created(null).body(RoomView.builder().roomResult(result).build());
     }
 
     @GetMapping(value = "/{room_id}/rank")

--- a/gotbetter/src/main/java/pcrc/gotbetter/setting/BatchConfig.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/setting/BatchConfig.java
@@ -86,7 +86,8 @@ public class BatchConfig {
                         if (lastDate.isBefore(now)) {
                             updatePercentSum(room.getRoomId(), room.getCurrentWeek());
                             int nextWeek = room.getCurrentWeek() + 1;
-                            roomRepository.updateCurrentWeek(room.getRoomId(), nextWeek);
+                            room.updateCurrentWeekToNext();
+                            roomRepository.save(room);
                             log.info("room_id: " + room.getRoomId() + ", start_date: " + room.getStartDate()
                                     + ", current_week/week: " + nextWeek + "/" + room.getWeek());
                         }


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #130 
<br/>

## ⚙️ 변경 사항 

Room 도메인의 spring data jpa과 querydsl 역할을 확실하게 구분

- querydsl에서 실행했던 update 쿼리를 spring data jpa에서 실행하도록 수정

<br/>

## 💦 변경한 이유

- spring data jpa와 querydsl의 특성을 살려서 효율적으로 사용하기 위함.

<br/>

## 💻 테스트 사항

- 어떻게 테스트를 실행했는지 작성

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
