### PR TITLE
Refactor/136 refactor join request 뷰 테이블 사용 대신 joinrequestrepository에 조인 쿼리 추가하여 사용

### DIFF
--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/entity/JoinRequest.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/entity/JoinRequest.java
@@ -19,11 +19,16 @@ import org.hibernate.annotations.DynamicUpdate;
 public class JoinRequest extends BaseTimeEntity {
     @EmbeddedId
     private JoinRequestId joinRequestId;
+    @Column(nullable = false)
     private Boolean accepted;
 
     @Builder
     public JoinRequest(JoinRequestId joinRequestId, Boolean accepted) {
         this.joinRequestId = joinRequestId;
         this.accepted = accepted;
+    }
+
+    public void updateAcceptedToJoin() {
+        this.accepted = true;
     }
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/entity/JoinRequestId.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/entity/JoinRequestId.java
@@ -13,9 +13,9 @@ import java.io.Serializable;
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class JoinRequestId implements Serializable {
-    @Column(name = "user_id")
+    @Column(name = "user_id", nullable = false)
     private Long userId;
-    @Column(name = "room_id")
+    @Column(name = "room_id", nullable = false)
     private Long roomId;
 
     @Builder

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/entity/Participant.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/entity/Participant.java
@@ -19,15 +19,17 @@ import org.hibernate.annotations.DynamicUpdate;
 public class Participant extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "participant_id")
+    @Column(name = "participant_id", nullable = false)
     private Long participantId;
-    @Column(name = "user_id")
+    @Column(name = "user_id", nullable = false)
     private Long userId;
-    @Column(name = "room_id")
+    @Column(name = "room_id", nullable = false)
     private Long roomId;
+    @Column(nullable = false)
     private Boolean authority;
-    @Column(name = "percent_sum")
+    @Column(name = "percent_sum", nullable = false)
     private Float percentSum;
+    @Column(nullable = false)
     private Integer refund;
 
     @Builder

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/JoinRequestDto.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/JoinRequestDto.java
@@ -1,0 +1,21 @@
+package pcrc.gotbetter.participant.data_access.repository;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import pcrc.gotbetter.participant.data_access.entity.JoinRequest;
+import pcrc.gotbetter.room.data_access.entity.Room;
+import pcrc.gotbetter.user.data_access.entity.User;
+import pcrc.gotbetter.user.data_access.entity.UserSet;
+
+@Getter
+@AllArgsConstructor
+public class JoinRequestDto {
+	private JoinRequest joinRequest;
+	private Room room;
+	private User user;
+	private UserSet userSet;
+
+	// 생성자, getter, setter 생략
+
+	// 필요한 경우 다른 생성자도 추가할 수 있습니다.
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/JoinRequestQueryRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/JoinRequestQueryRepository.java
@@ -1,0 +1,11 @@
+package pcrc.gotbetter.participant.data_access.repository;
+
+import java.util.List;
+
+public interface JoinRequestQueryRepository {
+
+    JoinRequestDto findJoinRequest(Long userId, Long roomId, Boolean accepted);
+
+    List<JoinRequestDto> findJoinRequestList(Long userId, Long roomId, Boolean accepted);
+
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/JoinRequestRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/JoinRequestRepository.java
@@ -6,6 +6,8 @@ import pcrc.gotbetter.participant.data_access.entity.JoinRequestId;
 
 import java.util.Optional;
 
-public interface JoinRequestRepository extends JpaRepository<JoinRequest, JoinRequestId> {
+public interface JoinRequestRepository extends JpaRepository<JoinRequest, JoinRequestId>, JoinRequestQueryRepository {
+
     Optional<JoinRequest> findByJoinRequestId(JoinRequestId joinRequestId);
+
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/JoinRequestRepositoryImpl.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/JoinRequestRepositoryImpl.java
@@ -1,0 +1,65 @@
+package pcrc.gotbetter.participant.data_access.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import java.util.List;
+
+import static pcrc.gotbetter.participant.data_access.entity.QJoinRequest.joinRequest;
+import static pcrc.gotbetter.room.data_access.entity.QRoom.room;
+import static pcrc.gotbetter.user.data_access.entity.QUser.user;
+import static pcrc.gotbetter.user.data_access.entity.QUserSet.*;
+
+public class JoinRequestRepositoryImpl implements JoinRequestQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public JoinRequestRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+
+    @Override
+    public JoinRequestDto findJoinRequest(Long userId, Long roomId, Boolean accepted) {
+        return queryFactory
+                .select(Projections.constructor(JoinRequestDto.class,
+                    joinRequest, room, user, userSet))
+                .from(joinRequest)
+                .leftJoin(room).on(joinRequest.joinRequestId.roomId.eq(room.roomId)).fetchJoin()
+                .leftJoin(user).on(joinRequest.joinRequestId.userId.eq(user.userId)).fetchJoin()
+                .leftJoin(userSet).on(joinRequest.joinRequestId.userId.eq(userSet.userId)).fetchJoin()
+            .where(joinRequest.joinRequestId.userId.eq(userId),
+                joinRequest.joinRequestId.roomId.eq(roomId),
+                joinRequest.accepted.eq(accepted))
+                .fetchFirst();
+    }
+
+    @Override
+    public List<JoinRequestDto> findJoinRequestList(Long userId, Long roomId, Boolean accepted) {
+        return queryFactory
+            .select(Projections.constructor(JoinRequestDto.class,
+                joinRequest, room, user, userSet))
+            .from(joinRequest)
+            .leftJoin(room).on(joinRequest.joinRequestId.roomId.eq(room.roomId)).fetchJoin()
+            .leftJoin(user).on(joinRequest.joinRequestId.userId.eq(user.userId)).fetchJoin()
+            .leftJoin(userSet).on(joinRequest.joinRequestId.userId.eq(userSet.userId)).fetchJoin()
+            .where(eqUserId(userId),
+                eqRoomId(roomId),
+                eqAccepted(accepted))
+            .fetch();
+    }
+
+
+    private BooleanExpression eqUserId(Long userId) {
+        return userId == null ? null : joinRequest.joinRequestId.userId.eq(userId);
+    }
+
+    private BooleanExpression eqRoomId(Long roomId) {
+        return roomId == null ? null : joinRequest.joinRequestId.roomId.eq(roomId);
+    }
+
+    private BooleanExpression eqAccepted(Boolean accepted) {
+        return accepted == null ? null : joinRequest.accepted.eq(accepted);
+    }
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantQueryRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantQueryRepository.java
@@ -1,7 +1,6 @@
 package pcrc.gotbetter.participant.data_access.repository;
 
 public interface ParticipantQueryRepository {
-    void updateParticipateAccepted(Long userId, Long roomId);
     void updatePercentSum(Long participantId, Float percent); // batchconfig
     void updateRefund(Long participantId, Integer refund); // batchconfig
 

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantRepositoryImpl.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantRepositoryImpl.java
@@ -4,7 +4,6 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.transaction.annotation.Transactional;
 
-import static pcrc.gotbetter.participant.data_access.entity.QJoinRequest.joinRequest;
 import static pcrc.gotbetter.participant.data_access.entity.QParticipant.participant;
 
 public class ParticipantRepositoryImpl implements ParticipantQueryRepository {
@@ -13,16 +12,6 @@ public class ParticipantRepositoryImpl implements ParticipantQueryRepository {
 
     public ParticipantRepositoryImpl(JPAQueryFactory queryFactory) {
         this.queryFactory = queryFactory;
-    }
-
-    @Override
-    @Transactional
-    public void updateParticipateAccepted(Long userId, Long roomId) {
-        queryFactory
-                .update(joinRequest)
-                .where(joinRequestEqRoomId(roomId), joinRequestEqUserId(userId))
-                .set(joinRequest.accepted, true)
-                .execute();
     }
 
     @Override
@@ -70,16 +59,5 @@ public class ParticipantRepositoryImpl implements ParticipantQueryRepository {
 
     private BooleanExpression participantEqParticipantId(Long participantId) {
         return participantId == null ? null : participant.participantId.eq(participantId);
-    }
-
-    /**
-     * participate eq
-     */
-    private BooleanExpression joinRequestEqUserId(Long userId) {
-        return userId == null ? null : joinRequest.joinRequestId.userId.eq(userId);
-    }
-
-    private BooleanExpression joinRequestEqRoomId(Long roomId) {
-        return roomId == null ? null : joinRequest.joinRequestId.roomId.eq(roomId);
     }
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ViewRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ViewRepository.java
@@ -1,15 +1,12 @@
 package pcrc.gotbetter.participant.data_access.repository;
 
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 import pcrc.gotbetter.participant.data_access.view.EnteredView;
-import pcrc.gotbetter.participant.data_access.view.TryEnterView;
 
 import java.util.List;
 
 import static pcrc.gotbetter.participant.data_access.view.QEnteredView.enteredView;
-import static pcrc.gotbetter.participant.data_access.view.QTryEnterView.tryEnterView;
 
 @Repository
 public class ViewRepository {
@@ -49,36 +46,5 @@ public class ViewRepository {
                         enteredView.roomId.eq(roomId))
                 .fetchFirst();
         return exists != null;
-    }
-
-    public TryEnterView tryEnterByUserIdRoomId(Long userId, Long roomId, Boolean accepted) {
-        return queryFactory
-                .selectFrom(tryEnterView)
-                .where(tryEnterViewEqUserId(userId),
-                        tryEnterViewEqRoomId(roomId),
-                        tryEnterViewEqAccepted(accepted))
-                .fetchFirst();
-    }
-
-    public List<TryEnterView> tryEnterListByUserIdRoomId(Long userId, Long roomId, Boolean accepted) {
-        return queryFactory
-                .selectFrom(tryEnterView)
-                .where(tryEnterViewEqUserId(userId),
-                        tryEnterViewEqRoomId(roomId),
-                        tryEnterViewEqAccepted(accepted))
-                .fetch();
-    }
-
-    /**
-     * try-enter view eq
-     */
-    private BooleanExpression tryEnterViewEqUserId(Long userId) {
-        return userId == null ? null : tryEnterView.tryEnterId.userId.eq(userId);
-    }
-    private BooleanExpression tryEnterViewEqRoomId(Long roomId) {
-        return roomId == null ? null : tryEnterView.tryEnterId.roomId.eq(roomId);
-    }
-    private BooleanExpression tryEnterViewEqAccepted(Boolean accepted) {
-        return accepted == null ? null : tryEnterView.accepted.eq(accepted);
     }
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/service/ParticipantReadUseCase.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/service/ParticipantReadUseCase.java
@@ -3,8 +3,8 @@ package pcrc.gotbetter.participant.service;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import pcrc.gotbetter.participant.data_access.repository.JoinRequestDto;
 import pcrc.gotbetter.participant.data_access.view.EnteredView;
-import pcrc.gotbetter.participant.data_access.view.TryEnterView;
 
 import java.util.List;
 
@@ -36,17 +36,17 @@ public interface ParticipantReadUseCase {
                     .build();
         }
 
-        public static FindParticipantResult findByParticipant(TryEnterView view, Long participantId,
-                                                              Boolean authority, String authId) {
+        public static FindParticipantResult findByParticipant(JoinRequestDto joinRequestResultDTO,
+            Long participantId, Boolean authority) {
             return FindParticipantResult.builder()
-                    .participantId(participantId)
-                    .userId(view.getTryEnterId().getUserId())
-                    .authId(authId)
-                    .username(view.getUsernameNick())
-                    .email(view.getEmail())
-                    .profile(view.getProfile())
-                    .authority(authority)
-                    .build();
+                .participantId(participantId)
+                .userId(joinRequestResultDTO.getUser().getUserId())
+                .authId(joinRequestResultDTO.getUserSet().getAuthId())
+                .username(joinRequestResultDTO.getUser().getUsername())
+                .email(joinRequestResultDTO.getUser().getEmail())
+                .profile(joinRequestResultDTO.getUser().getProfile())
+                .authority(authority)
+                .build();
         }
     }
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/room/service/RoomReadUseCase.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/room/service/RoomReadUseCase.java
@@ -3,7 +3,7 @@ package pcrc.gotbetter.room.service;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
-import pcrc.gotbetter.participant.data_access.view.TryEnterView;
+import pcrc.gotbetter.participant.data_access.repository.JoinRequestDto;
 import pcrc.gotbetter.room.data_access.entity.Room;
 
 import java.util.List;
@@ -54,23 +54,23 @@ public interface RoomReadUseCase {
                     .build();
         }
 
-        public static FindRoomResult findByRoom(TryEnterView tryEnterView, String roomCategory, String rule) {
+        public static FindRoomResult findByRoom(JoinRequestDto joinRequestDto, String roomCategory, String rule) {
             return FindRoomResult.builder()
-                    .roomId(tryEnterView.getTryEnterId().getRoomId())
-                    .title(tryEnterView.getTitle())
-                    .maxUserNum(tryEnterView.getMaxUserNum())
-                    .currentUserNum(tryEnterView.getCurrentUserNum())
-                    .startDate(tryEnterView.getStartDate().toString())
-                    .week(tryEnterView.getWeek())
-                    .currentWeek(tryEnterView.getCurrentWeek())
-                    .entryFee(tryEnterView.getEntryFee())
-                    .roomCode(tryEnterView.getRoomCode())
-                    .account(tryEnterView.getAccount())
-                    .roomCategory(roomCategory)
-                    .description(tryEnterView.getDescription() == null ? "" : tryEnterView.getDescription())
-                    .totalEntryFee(tryEnterView.getTotalEntryFee())
-                    .rule(rule)
-                    .build();
+                .roomId(joinRequestDto.getRoom().getRoomId())
+                .title(joinRequestDto.getRoom().getTitle())
+                .maxUserNum(joinRequestDto.getRoom().getMaxUserNum())
+                .currentUserNum(joinRequestDto.getRoom().getCurrentUserNum())
+                .startDate(joinRequestDto.getRoom().getStartDate().toString())
+                .week(joinRequestDto.getRoom().getWeek())
+                .currentWeek(joinRequestDto.getRoom().getCurrentWeek())
+                .entryFee(joinRequestDto.getRoom().getEntryFee())
+                .roomCode(joinRequestDto.getRoom().getRoomCode())
+                .account(joinRequestDto.getRoom().getAccount())
+                .roomCategory(roomCategory)
+                .description(joinRequestDto.getRoom().getDescription() == null ? "" : joinRequestDto.getRoom().getDescription())
+                .totalEntryFee(joinRequestDto.getRoom().getTotalEntryFee())
+                .rule(rule)
+                .build();
         }
     }
 

--- a/gotbetter/src/main/java/pcrc/gotbetter/setting/BaseTimeEntity.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/setting/BaseTimeEntity.java
@@ -3,6 +3,8 @@ package pcrc.gotbetter.setting;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -16,9 +18,23 @@ import java.time.LocalDateTime;
 public abstract class BaseTimeEntity {
 
     @CreatedDate
-    @Column(updatable = false)
+    @Column(updatable = false, nullable = false)
     private LocalDateTime created_date;
 
     @LastModifiedDate
+    @Column(nullable = false)
     private LocalDateTime updated_date;
+
+    @PrePersist
+    public void updateCreatedDate() {
+        this.created_date = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void updateUpdatedDate() {
+        this.updated_date = LocalDateTime.now();
+    }
+
+    // post , pre
+    // created_by, updated_by
 }


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #136 
<br/>

## ⚙️ 변경 사항 

join request 뷰 테이블 사용 대신 joinrequestrepository에 조인 쿼리 추가하여 사용
- join_request_veiw 테이블 대신 querydsl 조인 쿼리 사용
- tryEnterView 클래스 사용하는 코드 모두 수정

<br/>

## 💦 변경한 이유

- 쿼리를 추가로 더 요청하는 것 대신 조인을 통해 필요한 데이터 가져옴.

<br/>

## 💻 테스트 사항

- postman 테스트함.

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
