### PR TITLE
[refactor] participantService에서 사용한 뷰 테이블을 이용한 쿼리를 querydsl 쿼리로 수정

### DIFF
--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/dto/JoinRequestDto.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/dto/JoinRequestDto.java
@@ -1,4 +1,4 @@
-package pcrc.gotbetter.participant.data_access.repository;
+package pcrc.gotbetter.participant.data_access.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/dto/ParticipantDto.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/dto/ParticipantDto.java
@@ -1,0 +1,53 @@
+package pcrc.gotbetter.participant.data_access.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import pcrc.gotbetter.participant.data_access.entity.Participant;
+import pcrc.gotbetter.room.data_access.entity.Room;
+import pcrc.gotbetter.user.data_access.entity.User;
+
+@Getter
+@AllArgsConstructor
+public class ParticipantDto {
+	// participant
+	private Participant participant;
+	private Long participantId;
+	private Boolean authority;
+
+	// room
+	private Room room;
+	private Long roomId;
+	private Integer currentUserNum;
+	private Integer currentWeek;
+
+	// user
+	private User user;
+	private Long userId;
+
+	// userset
+	private String authId;
+
+	// ParticipantService
+	public ParticipantDto(Long participantId, Boolean authority,
+		User user, String authId) {
+		this.participantId = participantId;
+		this.authority = authority;
+		this.user = user;
+		this.authId = authId;
+	}
+
+	// DetailPlanEvalService
+	// public ParticipantDto(Long participantId, Long roomId,
+	// 	Integer currentUserNum, Integer currentWeek, Long userId) {
+	// 	this.participantId = participantId;
+	// 	this.roomId = roomId;
+	// 	this.currentUserNum = currentUserNum;
+	// 	this.currentWeek = currentWeek;
+	// 	this.userId = userId;
+	// }
+	//
+	// public ParticipantDto(Participant participant, Room room) {
+	// 	this.participant = participant;
+	// 	this.room = room;
+	// }
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/JoinRequestQueryRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/JoinRequestQueryRepository.java
@@ -2,6 +2,8 @@ package pcrc.gotbetter.participant.data_access.repository;
 
 import java.util.List;
 
+import pcrc.gotbetter.participant.data_access.dto.JoinRequestDto;
+
 public interface JoinRequestQueryRepository {
 
     JoinRequestDto findJoinRequest(Long userId, Long roomId, Boolean accepted);

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/JoinRequestRepositoryImpl.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/JoinRequestRepositoryImpl.java
@@ -9,7 +9,9 @@ import java.util.List;
 import static pcrc.gotbetter.participant.data_access.entity.QJoinRequest.joinRequest;
 import static pcrc.gotbetter.room.data_access.entity.QRoom.room;
 import static pcrc.gotbetter.user.data_access.entity.QUser.user;
-import static pcrc.gotbetter.user.data_access.entity.QUserSet.*;
+import static pcrc.gotbetter.user.data_access.entity.QUserSet.userSet;
+
+import pcrc.gotbetter.participant.data_access.dto.JoinRequestDto;
 
 public class JoinRequestRepositoryImpl implements JoinRequestQueryRepository {
 

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantQueryRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantQueryRepository.java
@@ -1,9 +1,17 @@
 package pcrc.gotbetter.participant.data_access.repository;
 
+import java.util.List;
+
+import pcrc.gotbetter.participant.data_access.dto.ParticipantDto;
+import pcrc.gotbetter.participant.data_access.entity.Participant;
+
 public interface ParticipantQueryRepository {
     void updatePercentSum(Long participantId, Float percent); // batchconfig
     void updateRefund(Long participantId, Integer refund); // batchconfig
 
     Boolean isMatchedLeader(Long userId, Long roomId);
 
+    Participant findByUserIdAndRoomId(Long userId, Long roomId);
+
+    List<ParticipantDto> findUserInfoList(Long roomId);
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/service/ParticipantReadUseCase.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/service/ParticipantReadUseCase.java
@@ -3,8 +3,8 @@ package pcrc.gotbetter.participant.service;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
-import pcrc.gotbetter.participant.data_access.repository.JoinRequestDto;
-import pcrc.gotbetter.participant.data_access.view.EnteredView;
+import pcrc.gotbetter.participant.data_access.dto.JoinRequestDto;
+import pcrc.gotbetter.participant.data_access.dto.ParticipantDto;
 
 import java.util.List;
 
@@ -24,16 +24,16 @@ public interface ParticipantReadUseCase {
         private final String profile;
         private final Boolean authority;
 
-        public static FindParticipantResult findByParticipant(EnteredView view, String authId) {
+        public static FindParticipantResult findByParticipant(ParticipantDto participantDto) {
             return FindParticipantResult.builder()
-                    .participantId(view.getParticipantId())
-                    .userId(view.getUserId())
-                    .authId(authId)
-                    .username(view.getUsernameNick())
-                    .email(view.getEmail())
-                    .profile(view.getProfile())
-                    .authority(view.getAuthority())
-                    .build();
+                .participantId(participantDto.getParticipantId())
+                .userId(participantDto.getUser().getUserId())
+                .authId(participantDto.getAuthId())
+                .username(participantDto.getUser().getUsername())
+                .email(participantDto.getUser().getEmail())
+                .profile(participantDto.getUser().getProfile())
+                .authority(participantDto.getAuthority())
+                .build();
         }
 
         public static FindParticipantResult findByParticipant(JoinRequestDto joinRequestResultDTO,

--- a/gotbetter/src/main/java/pcrc/gotbetter/room/service/RoomReadUseCase.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/room/service/RoomReadUseCase.java
@@ -3,7 +3,7 @@ package pcrc.gotbetter.room.service;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
-import pcrc.gotbetter.participant.data_access.repository.JoinRequestDto;
+import pcrc.gotbetter.participant.data_access.dto.JoinRequestDto;
 import pcrc.gotbetter.room.data_access.entity.Room;
 
 import java.util.List;

--- a/gotbetter/src/main/java/pcrc/gotbetter/room/service/RoomService.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/room/service/RoomService.java
@@ -9,7 +9,7 @@ import pcrc.gotbetter.common.data_access.repository.CommonCodeRepository;
 import pcrc.gotbetter.participant.data_access.entity.JoinRequestId;
 import pcrc.gotbetter.participant.data_access.entity.Participant;
 import pcrc.gotbetter.participant.data_access.entity.JoinRequest;
-import pcrc.gotbetter.participant.data_access.repository.JoinRequestDto;
+import pcrc.gotbetter.participant.data_access.dto.JoinRequestDto;
 import pcrc.gotbetter.participant.data_access.repository.ViewRepository;
 import pcrc.gotbetter.participant.data_access.view.EnteredView;
 import pcrc.gotbetter.room.data_access.entity.Room;
@@ -153,6 +153,7 @@ public class RoomService implements RoomOperationUseCase, RoomReadUseCase {
             throw new GotBetterException(MessageType.NOT_FOUND);
         }
 
+        // participant - room - user
         List<EnteredView> enteredViewList = viewRepository.enteredListByRoomId(roomId);
         List<FindRankResult> findRankResultList = new ArrayList<>();
 


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #138 
<br/>

## ⚙️ 변경 사항 

participantService에서 사용한 뷰 테이블을 이용한 쿼리를 querydsl 쿼리로 수정

<br/>

## 💦 변경한 이유

- 쿼리를 추가로 더 요청하는 것 대신 조인을 통해 필요한 데이터 가져옴.

<br/>

## 💻 테스트 사항

- 어떻게 테스트를 실행했는지 작성

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
