### PR TITLE
Refactor/126 refactor plan planevaluation 도메인의 spring data jpa과 querydsl 역할을 확실하게 구분

### DIFF
--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/dto/ParticipantDto.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/dto/ParticipantDto.java
@@ -36,6 +36,12 @@ public class ParticipantDto {
 		this.authId = authId;
 	}
 
+	// plan
+	public ParticipantDto(Participant participant, Room room) {
+		this.participant = participant;
+		this.room = room;
+	}
+
 	// DetailPlanEvalService
 	// public ParticipantDto(Long participantId, Long roomId,
 	// 	Integer currentUserNum, Integer currentWeek, Long userId) {

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantQueryRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantQueryRepository.java
@@ -13,5 +13,9 @@ public interface ParticipantQueryRepository {
 
     Participant findByUserIdAndRoomId(Long userId, Long roomId);
 
+    Boolean existsByUserIdAndRoomId(Long userId, Long roomId);
+
     List<ParticipantDto> findUserInfoList(Long roomId);
+
+    ParticipantDto findRoom(Long participantId);
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantRepository.java
@@ -7,4 +7,6 @@ import pcrc.gotbetter.participant.data_access.entity.Participant;
 @Repository
 public interface ParticipantRepository extends JpaRepository<Participant, Long>, ParticipantQueryRepository {
 
+	Participant findByParticipantId(Long participantId);
+
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/plan/data_access/dto/PlanDto.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/plan/data_access/dto/PlanDto.java
@@ -1,0 +1,13 @@
+package pcrc.gotbetter.plan.data_access.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import pcrc.gotbetter.plan.data_access.entity.Plan;
+import pcrc.gotbetter.room.data_access.entity.Room;
+
+@Getter
+@AllArgsConstructor
+public class PlanDto {
+	private Plan plan;
+	private Room room;
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/plan/data_access/entity/Plan.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/plan/data_access/entity/Plan.java
@@ -50,4 +50,8 @@ public class Plan extends BaseTimeEntity {
         this.threeDaysPassed = threeDaysPassed;
         this.rejected = rejected;
     }
+
+    public void updateRejected(Boolean rejected) {
+        this.rejected = rejected;
+    }
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/plan/data_access/repository/PlanQueryRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/plan/data_access/repository/PlanQueryRepository.java
@@ -1,5 +1,6 @@
 package pcrc.gotbetter.plan.data_access.repository;
 
+import pcrc.gotbetter.plan.data_access.dto.PlanDto;
 import pcrc.gotbetter.plan.data_access.entity.Plan;
 
 import java.util.HashMap;
@@ -15,4 +16,7 @@ public interface PlanQueryRepository {
     Boolean existsByParticipantId(Long participantId);
     List<Plan> findListByRoomId(Long roomId, Integer passedWeek);
     List<HashMap<String, Object>> findPushNotification();
+
+    // join
+    PlanDto findPlanJoinRoom(Long planId);
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/plan/data_access/repository/PlanRepositoryImpl.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/plan/data_access/repository/PlanRepositoryImpl.java
@@ -1,9 +1,12 @@
 package pcrc.gotbetter.plan.data_access.repository;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.transaction.annotation.Transactional;
+
+import pcrc.gotbetter.plan.data_access.dto.PlanDto;
 import pcrc.gotbetter.plan.data_access.entity.Plan;
 
 import java.time.LocalDate;
@@ -104,6 +107,16 @@ public class PlanRepositoryImpl implements PlanQueryRepository {
             result.add(hashMap);
         }
         return result;
+    }
+
+    @Override
+    public PlanDto findPlanJoinRoom(Long planId) {
+        return queryFactory
+            .select(Projections.constructor(PlanDto.class, plan, room))
+            .from(plan)
+            .leftJoin(room).on(plan.participantInfo.roomId.eq(room.roomId)).fetchJoin()
+            .where(eqPlanId(planId))
+            .fetchFirst();
     }
 
     /**

--- a/gotbetter/src/main/java/pcrc/gotbetter/plan_evaluation/data_access/dto/PlanEvaluationDto.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/plan_evaluation/data_access/dto/PlanEvaluationDto.java
@@ -1,0 +1,13 @@
+package pcrc.gotbetter.plan_evaluation.data_access.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import pcrc.gotbetter.plan.data_access.entity.Plan;
+import pcrc.gotbetter.plan_evaluation.data_access.entity.PlanEvaluation;
+
+@Getter
+@AllArgsConstructor
+public class PlanEvaluationDto {
+	private PlanEvaluation planEvaluation;
+	private Plan plan;
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/plan_evaluation/data_access/repository/PlanEvaluationQueryRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/plan_evaluation/data_access/repository/PlanEvaluationQueryRepository.java
@@ -1,9 +1,7 @@
 package pcrc.gotbetter.plan_evaluation.data_access.repository;
 
 public interface PlanEvaluationQueryRepository {
-    // insert, update, delete
-    void deletePlanEvaluation(Long planId, Long participantId);
 
-    // select
     Boolean existsEval(Long planId, Long participantId);
+
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/plan_evaluation/data_access/repository/PlanEvaluationRepositoryImpl.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/plan_evaluation/data_access/repository/PlanEvaluationRepositoryImpl.java
@@ -2,7 +2,6 @@ package pcrc.gotbetter.plan_evaluation.data_access.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.transaction.Transactional;
 
 import static pcrc.gotbetter.plan_evaluation.data_access.entity.QPlanEvaluation.planEvaluation;
 
@@ -11,16 +10,6 @@ public class PlanEvaluationRepositoryImpl implements PlanEvaluationQueryReposito
 
     public PlanEvaluationRepositoryImpl(JPAQueryFactory queryFactory) {
         this.queryFactory = queryFactory;
-    }
-
-    @Override
-    @Transactional
-    public void deletePlanEvaluation(Long planId, Long participantId) {
-        queryFactory
-                .delete(planEvaluation)
-                .where(planEvaluationEqPlanId(planId),
-                        planEvaluationEqParticipantId(participantId))
-                .execute();
     }
 
     @Override

--- a/gotbetter/src/main/java/pcrc/gotbetter/plan_evaluation/service/PlanEvaluationReadUseCase.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/plan_evaluation/service/PlanEvaluationReadUseCase.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import pcrc.gotbetter.plan.data_access.entity.Plan;
 
 public interface PlanEvaluationReadUseCase {
 
@@ -24,18 +25,17 @@ public interface PlanEvaluationReadUseCase {
         private final Long planId;
         private final Boolean rejected;
         private final Integer dislikeCount;
-        private final Boolean checked;
+        private final Boolean checked; // 사용자가 계획 평가 했는지
 
-        public static FindPlanEvaluationResult findByPlanEvaluation(Long planId,
-                                                                    Boolean rejected,
+        public static FindPlanEvaluationResult findByPlanEvaluation(Plan plan,
                                                                     Integer dislikeCount,
                                                                     Boolean checked) {
             return FindPlanEvaluationResult.builder()
-                    .planId(planId)
-                    .rejected(rejected)
-                    .dislikeCount(dislikeCount)
-                    .checked(checked)
-                    .build();
+                .planId(plan.getPlanId())
+                .rejected(plan.getRejected())
+                .dislikeCount(dislikeCount)
+                .checked(checked)
+                .build();
         }
     }
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/plan_evaluation/service/PlanEvaluationService.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/plan_evaluation/service/PlanEvaluationService.java
@@ -4,13 +4,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pcrc.gotbetter.detail_plan.data_access.repository.DetailPlanRepository;
-import pcrc.gotbetter.participant.data_access.repository.ViewRepository;
-import pcrc.gotbetter.participant.data_access.view.EnteredView;
+import pcrc.gotbetter.participant.data_access.entity.Participant;
+import pcrc.gotbetter.participant.data_access.repository.ParticipantRepository;
+import pcrc.gotbetter.plan.data_access.dto.PlanDto;
 import pcrc.gotbetter.plan.data_access.entity.Plan;
 import pcrc.gotbetter.plan.data_access.repository.PlanRepository;
 import pcrc.gotbetter.plan_evaluation.data_access.entity.PlanEvaluation;
 import pcrc.gotbetter.plan_evaluation.data_access.entity.PlanEvaluationId;
 import pcrc.gotbetter.plan_evaluation.data_access.repository.PlanEvaluationRepository;
+import pcrc.gotbetter.room.data_access.entity.Room;
 import pcrc.gotbetter.setting.http_api.GotBetterException;
 import pcrc.gotbetter.setting.http_api.MessageType;
 
@@ -25,85 +27,85 @@ public class PlanEvaluationService implements PlanEvaluationOperationUseCase,  P
     private final PlanEvaluationRepository planEvaluationRepository;
     private final PlanRepository planRepository;
     private final DetailPlanRepository detailPlanRepository;
-    private final ViewRepository viewRepository;
+    private final ParticipantRepository participantRepository;
 
     @Autowired
     public PlanEvaluationService(PlanEvaluationRepository planEvaluationRepository, PlanRepository planRepository,
-                                 DetailPlanRepository detailPlanRepository, ViewRepository viewRepository) {
+                                 DetailPlanRepository detailPlanRepository, ParticipantRepository participantRepository) {
         this.planEvaluationRepository = planEvaluationRepository;
         this.planRepository = planRepository;
         this.detailPlanRepository = detailPlanRepository;
-        this.viewRepository = viewRepository;
+        this.participantRepository = participantRepository;
     }
 
     @Override
     @Transactional
     public FindPlanEvaluationResult createPlanEvaluation(PlanEvaluationCommand command) {
-        Plan plan = validatePlan(command.getPlanId());
-        EnteredView enteredView = validateEnteredView(plan.getParticipantInfo().getRoomId());
-
-        validateDate(plan, enteredView.getCurrentWeek());
-        if (plan.getRejected()) {
-            throw new GotBetterException(MessageType.FORBIDDEN);
-        }
-        if (!detailPlanRepository.existsByPlanId(plan.getPlanId())) {
-            throw new GotBetterException(MessageType.FORBIDDEN);
-        }
-        if (planEvaluationRepository.existsEval(plan.getPlanId(), enteredView.getParticipantId())) {
-            throw new GotBetterException(MessageType.CONFLICT);
-        }
-
-        boolean rejected = false;
+        // 평가를 할 수 있는 상태인지 확인
+        PlanDto planDto = validatePlanRoom(command.getPlanId());
+        Participant evaluator = validateCanEvaluate(planDto);
+        Plan planInfo = planDto.getPlan();
+        Room roomInfo = planDto.getRoom();
+        // 평가 리스트 조회
+        List<PlanEvaluation> planEvaluations = planEvaluationRepository.findByPlanEvaluationIdPlanId(command.getPlanId());
         boolean checked = false;
         int planEvalSize = 0;
-        List<PlanEvaluation> planEvaluations = planEvaluationRepository.findByPlanEvaluationIdPlanId(command.getPlanId());
-        if (Math.floor(enteredView.getCurrentUserNum() - 1) / 2 < planEvaluations.size() + 1) {
-            planRepository.updateRejected(plan.getPlanId(), true);
-            planEvaluationRepository.deleteByPlanEvaluationIdPlanId(plan.getPlanId());
-            detailPlanRepository.deleteByPlanId(plan.getPlanId());
-            rejected = true;
+
+        // 과반수인지 확인
+        if (Math.floor(roomInfo.getCurrentUserNum() - 1) / 2 < planEvaluations.size() + 1) {
+            // 재작성 표시 업데이트
+            planInfo.updateRejected(true);
+            planRepository.save(planInfo);
+            // 기존 평가들 삭제
+            planEvaluationRepository.deleteByPlanEvaluationIdPlanId(planInfo.getPlanId());
+            // 기존 세부계획들 삭제
+            detailPlanRepository.deleteByPlanId(planInfo.getPlanId());
         } else {
+            // 계획 평가 생성
             PlanEvaluation planEvaluation = PlanEvaluation.builder()
-                    .planEvaluationId(PlanEvaluationId.builder()
-                            .planId(plan.getPlanId())
-                            .participantId(enteredView.getParticipantId())
-                            .userId(enteredView.getUserId())
-                            .roomId(enteredView.getRoomId())
-                            .build())
-                    .build();
+                .planEvaluationId(PlanEvaluationId.builder()
+                    .planId(planInfo.getPlanId())
+                    .participantId(evaluator.getParticipantId())
+                    .userId(evaluator.getUserId())
+                    .roomId(evaluator.getRoomId())
+                    .build())
+                .build();
             planEvaluationRepository.save(planEvaluation);
             checked = true;
             planEvalSize = planEvaluations.size() + 1;
         }
-        return FindPlanEvaluationResult.findByPlanEvaluation(plan.getPlanId(), rejected,
-                planEvalSize, checked);
+        return FindPlanEvaluationResult.findByPlanEvaluation(planInfo, planEvalSize, checked);
     }
 
     @Override
     public FindPlanEvaluationResult getPlanDislike(PlanEvaluationFindQuery query) {
         Plan plan = validatePlan(query.getPlanId());
-        EnteredView enteredView = validateEnteredView(plan.getParticipantInfo().getRoomId());
+        // 사용자가 방에 속해 있는지 확인
+        Participant participant = validateUserInRoom(plan.getParticipantInfo().getRoomId());
         List<PlanEvaluation> planEvaluations = planEvaluationRepository.findByPlanEvaluationIdPlanId(query.getPlanId());
         boolean checked = false;
 
         for (PlanEvaluation p : planEvaluations) {
-            if (Objects.equals(p.getPlanEvaluationId().getUserId(), enteredView.getUserId())) {
+            if (Objects.equals(p.getPlanEvaluationId().getUserId(), participant.getUserId())) {
                 checked = true;
                 break;
             }
         }
-        return FindPlanEvaluationResult.findByPlanEvaluation(plan.getPlanId(), plan.getRejected(),
-                planEvaluations.size(), checked);
+        return FindPlanEvaluationResult.findByPlanEvaluation(plan, planEvaluations.size(), checked);
     }
 
     @Override
     public void deletePlanEvaluation(PlanEvaluationCommand command) {
-        Plan plan = validatePlan(command.getPlanId());
-        EnteredView enteredView = validateEnteredView(plan.getParticipantInfo().getRoomId());
+        // // plan 정보 조회
+        PlanDto planDto = validatePlanRoom(command.getPlanId());
+        Plan planInfo = planDto.getPlan();
+        Room roomInfo = planDto.getRoom();
+        // 사용자가 방에 속해 있는지 확인
+        Participant participant = validateUserInRoom(roomInfo.getRoomId());
 
-        validateDate(plan, enteredView.getCurrentWeek());
-        if (planEvaluationRepository.existsEval(plan.getPlanId(), enteredView.getParticipantId())) {
-            planEvaluationRepository.deletePlanEvaluation(plan.getPlanId(), enteredView.getParticipantId());
+        validateDate(planInfo, roomInfo.getCurrentWeek());
+        if (planEvaluationRepository.existsEval(planInfo.getPlanId(), participant.getParticipantId())) {
+            planEvaluationRepository.deletePlanEvaluation(planInfo.getPlanId(), participant.getParticipantId());
             return;
         }
         throw new GotBetterException(MessageType.NOT_FOUND);
@@ -112,19 +114,54 @@ public class PlanEvaluationService implements PlanEvaluationOperationUseCase,  P
     /**
      * validate
      */
+    private PlanDto validatePlanRoom(Long planId) {
+        PlanDto planDto = planRepository.findPlanJoinRoom(planId);
+
+        if (planDto == null) {
+            throw new GotBetterException(MessageType.NOT_FOUND);
+        }
+        return planDto;
+    }
+
+    private Participant validateCanEvaluate(PlanDto planDto) {
+        Plan planInfo = planDto.getPlan();
+        Room roomInfo = planDto.getRoom();
+        // 사용자가 방에 속해 있는지 확인
+        Participant participant = validateUserInRoom(roomInfo.getRoomId());
+
+        // 사용자 본인의 계획인지 확인
+        if (Objects.equals(planInfo.getParticipantInfo().getUserId(), getCurrentUserId())) {
+            throw new GotBetterException(MessageType.FORBIDDEN);
+        }
+        // 평가를 할 수 있는 날짜인지 확인
+        validateDate(planInfo, roomInfo.getCurrentWeek());
+        // 플랜이 재작성되어야하는 상태인지 확인
+        if (planInfo.getRejected()) {
+            throw new GotBetterException(MessageType.FORBIDDEN);
+        }
+        // 세부 계획이 하나라도 작성되어있는지 확인
+        if (!detailPlanRepository.existsByPlanId(planInfo.getPlanId())) {
+            throw new GotBetterException(MessageType.FORBIDDEN);
+        }
+        // 이미 평가한 계획인지
+        if (planEvaluationRepository.existsEval(planInfo.getPlanId(), participant.getParticipantId())) {
+            throw new GotBetterException(MessageType.CONFLICT);
+        }
+        return participant;
+    }
+
+    private Participant validateUserInRoom(Long roomId) {
+        Participant participant = participantRepository.findByUserIdAndRoomId(getCurrentUserId(), roomId);
+        if (participant == null) {
+            throw new GotBetterException(MessageType.NOT_FOUND);
+        }
+        return participant;
+    }
+
     private Plan validatePlan(Long planId) {
         return planRepository.findByPlanId(planId).orElseThrow(() -> {
             throw new GotBetterException(MessageType.NOT_FOUND);
         });
-    }
-
-    private EnteredView validateEnteredView(Long roomId) {
-        EnteredView enteredView = viewRepository.enteredByUserIdRoomId(getCurrentUserId(), roomId);
-
-        if (enteredView == null) {
-            throw new GotBetterException(MessageType.NOT_FOUND);
-        }
-        return enteredView;
     }
 
     private void validateDate(Plan plan, Integer currentWeek) {

--- a/gotbetter/src/main/java/pcrc/gotbetter/plan_evaluation/service/PlanEvaluationService.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/plan_evaluation/service/PlanEvaluationService.java
@@ -105,7 +105,12 @@ public class PlanEvaluationService implements PlanEvaluationOperationUseCase,  P
 
         validateDate(planInfo, roomInfo.getCurrentWeek());
         if (planEvaluationRepository.existsEval(planInfo.getPlanId(), participant.getParticipantId())) {
-            planEvaluationRepository.deletePlanEvaluation(planInfo.getPlanId(), participant.getParticipantId());
+            planEvaluationRepository.deleteById(PlanEvaluationId.builder()
+                    .planId(planInfo.getPlanId())
+                    .participantId(participant.getParticipantId())
+                    .userId(participant.getUserId())
+                    .roomId(participant.getRoomId())
+                .build());
             return;
         }
         throw new GotBetterException(MessageType.NOT_FOUND);


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #126
<br/>

## ⚙️ 변경 사항 

plan과 planevaluation 도메인의 spring data jpa과 querydsl 역할을 확실하게 구분

- spring data jpa는 CRUD, querydsl은 조인과 같은 복잡한 쿼리 주로 실행
- 추가로 불필요한 뷰 테이블 사용을 없앰.

<br/>

## 💦 변경한 이유

- spring data jpa와 querydsl 사용을 좀 더 효율적으로 하기 위함.

<br/>

## 💻 테스트 사항

- 어떻게 테스트를 실행했는지 작성

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
