### PR TITLE
[refactor] DetailPlan, DetailPlanEvaluation 도메인 spring data jpa와 quer…

### DIFF
--- a/gotbetter/src/main/java/pcrc/gotbetter/detail_plan/data_access/dto/DetailPlanDto.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/detail_plan/data_access/dto/DetailPlanDto.java
@@ -1,0 +1,13 @@
+package pcrc.gotbetter.detail_plan.data_access.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import pcrc.gotbetter.detail_plan.data_access.entity.DetailPlan;
+import pcrc.gotbetter.room.data_access.entity.Room;
+
+@Getter
+@AllArgsConstructor
+public class DetailPlanDto {
+	private DetailPlan detailPlan;
+	private Room room;
+}

--- a/gotbetter/src/main/java/pcrc/gotbetter/detail_plan/data_access/entity/DetailPlan.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/detail_plan/data_access/entity/DetailPlan.java
@@ -45,4 +45,23 @@ public class DetailPlan extends BaseTimeEntity {
         this.approveComment = approveComment;
         this.rejected = rejected;
     }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void updateRejected(Boolean rejected) {
+        this.rejected = rejected;
+    }
+
+    public void updateDetailPlanCompleted(String approveComment) {
+        this.complete = true;
+        this.approveComment = approveComment;
+    }
+
+    public void updateDetailPlanUndo(Boolean rejected) {
+        this.complete = false;
+        this.approveComment = null;
+        this.rejected = rejected;
+    }
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/detail_plan/data_access/repository/DetailPlanQueryRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/detail_plan/data_access/repository/DetailPlanQueryRepository.java
@@ -1,19 +1,18 @@
 package pcrc.gotbetter.detail_plan.data_access.repository;
 
+import pcrc.gotbetter.detail_plan.data_access.dto.DetailPlanDto;
 import pcrc.gotbetter.detail_plan.data_access.entity.DetailPlan;
 
 import java.util.HashMap;
 
 public interface DetailPlanQueryRepository {
-    // insert, update, delete
-    void updateDetailContent(Long detailPlanId, String content);
-    void updateRejected(Long detailPlanId, Boolean rejected);
-    void updateDetailPlanCompleted(Long detailPlanId, String approveComment);
-    void updateDetailPlanUndo(Long detailPlanId, Boolean rejected);
-    void deleteDetailPlan(Long detailPlanId);
 
-    // select
     Boolean existsByPlanId(Long planId);
+
     HashMap<String, Long> countCompleteTrue(Long planId);
+
     DetailPlan findByDetailPlanId(Long detailPlanId);
+
+    // join
+    DetailPlanDto findByDetailJoinRoom(Long detailPlanId);
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/detail_plan/data_access/repository/DetailPlanRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/detail_plan/data_access/repository/DetailPlanRepository.java
@@ -9,5 +9,8 @@ import java.util.List;
 @Repository
 public interface DetailPlanRepository extends JpaRepository<DetailPlan, Long>, DetailPlanQueryRepository {
     List<DetailPlan> findByPlanId(Long planId);
+
     void deleteByPlanId(Long planId);
+
+    void deleteByDetailPlanId(Long detailPlanId);
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/detail_plan/data_access/repository/DetailPlanRepositoryImpl.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/detail_plan/data_access/repository/DetailPlanRepositoryImpl.java
@@ -1,15 +1,17 @@
 package pcrc.gotbetter.detail_plan.data_access.repository;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
-import jakarta.transaction.Transactional;
+import pcrc.gotbetter.detail_plan.data_access.dto.DetailPlanDto;
 import pcrc.gotbetter.detail_plan.data_access.entity.DetailPlan;
 
 import java.util.HashMap;
 
 import static pcrc.gotbetter.detail_plan.data_access.entity.QDetailPlan.detailPlan;
+import static pcrc.gotbetter.room.data_access.entity.QRoom.room;
 
 public class DetailPlanRepositoryImpl implements DetailPlanQueryRepository {
     private final JPAQueryFactory queryFactory;
@@ -18,58 +20,6 @@ public class DetailPlanRepositoryImpl implements DetailPlanQueryRepository {
     public DetailPlanRepositoryImpl(JPAQueryFactory queryFactory, EntityManager em) {
         this.queryFactory = queryFactory;
         this.em = em;
-    }
-
-    @Override
-    @Transactional
-    public void updateDetailContent(Long detailPlanId, String content) {
-        queryFactory
-                .update(detailPlan)
-                .set(detailPlan.content, content)
-                .where(detailPlanEqDetailPlanId(detailPlanId))
-                .execute();
-    }
-
-    @Override
-    @Transactional
-    public void updateRejected(Long detailPlanId, Boolean rejected) {
-        queryFactory
-                .update(detailPlan)
-                .set(detailPlan.rejected, rejected)
-                .where(detailPlanEqDetailPlanId(detailPlanId))
-                .execute();
-    }
-
-    @Override
-    @Transactional
-    public void updateDetailPlanCompleted(Long detailPlanId, String approveComment) {
-        queryFactory
-                .update(detailPlan)
-                .set(detailPlan.complete, true)
-                .set(detailPlan.approveComment, approveComment)
-                .where(detailPlanEqDetailPlanId(detailPlanId))
-                .execute();
-    }
-
-    @Override
-    @Transactional
-    public void updateDetailPlanUndo(Long detailPlanId, Boolean rejected) {
-        queryFactory
-                .update(detailPlan)
-                .set(detailPlan.complete, false)
-                .setNull(detailPlan.approveComment)
-                .set(detailPlan.rejected, rejected)
-                .where(detailPlanEqDetailPlanId(detailPlanId))
-                .execute();
-    }
-
-    @Override
-    @Transactional
-    public void deleteDetailPlan(Long detailPlanId) {
-        queryFactory
-                .delete(detailPlan)
-                .where(detailPlanEqDetailPlanId(detailPlanId))
-                .execute();
     }
 
     @Override
@@ -101,6 +51,16 @@ public class DetailPlanRepositoryImpl implements DetailPlanQueryRepository {
                 .selectFrom(detailPlan)
                 .where(detailPlanEqDetailPlanId(detailPlanId))
                 .fetchFirst();
+    }
+
+    @Override
+    public DetailPlanDto findByDetailJoinRoom(Long detailPlanId) {
+        return queryFactory
+            .select(Projections.constructor(DetailPlanDto.class, detailPlan, room))
+            .from(detailPlan)
+            .leftJoin(room).on(detailPlan.participantInfo.roomId.eq(room.roomId)).fetchJoin()
+            .where(detailPlanEqDetailPlanId(detailPlanId))
+            .fetchFirst();
     }
 
     /**

--- a/gotbetter/src/main/java/pcrc/gotbetter/detail_plan/service/DetailPlanCompleteService.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/detail_plan/service/DetailPlanCompleteService.java
@@ -5,17 +5,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pcrc.gotbetter.detail_plan.data_access.entity.DetailPlan;
 import pcrc.gotbetter.detail_plan.data_access.repository.DetailPlanRepository;
-import pcrc.gotbetter.detail_plan_evaluation.data_access.entity.DetailPlanEval;
 import pcrc.gotbetter.detail_plan_evaluation.data_access.repository.DetailPlanEvalRepository;
+import pcrc.gotbetter.plan.data_access.dto.PlanDto;
 import pcrc.gotbetter.plan.data_access.entity.Plan;
 import pcrc.gotbetter.plan.data_access.repository.PlanRepository;
 import pcrc.gotbetter.room.data_access.entity.Room;
-import pcrc.gotbetter.room.data_access.repository.RoomRepository;
 import pcrc.gotbetter.setting.http_api.GotBetterException;
 import pcrc.gotbetter.setting.http_api.MessageType;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Objects;
 
 import static pcrc.gotbetter.setting.security.SecurityUtil.getCurrentUserId;
@@ -24,16 +22,14 @@ import static pcrc.gotbetter.setting.security.SecurityUtil.getCurrentUserId;
 public class DetailPlanCompleteService implements DetailPlanCompleteOperationUseCase {
     private final DetailPlanRepository detailPlanRepository;
     private final DetailPlanEvalRepository detailPlanEvalRepository;
-    private final RoomRepository roomRepository;
     private final PlanRepository planRepository;
 
     @Autowired
     public DetailPlanCompleteService(DetailPlanRepository detailPlanRepository,
                                      DetailPlanEvalRepository detailPlanEvalRepository,
-                                     RoomRepository roomRepository, PlanRepository planRepository) {
+                                     PlanRepository planRepository) {
         this.detailPlanRepository = detailPlanRepository;
         this.detailPlanEvalRepository = detailPlanEvalRepository;
-        this.roomRepository = roomRepository;
         this.planRepository = planRepository;
     }
 
@@ -42,22 +38,23 @@ public class DetailPlanCompleteService implements DetailPlanCompleteOperationUse
         DetailPlan detailPlan = validateDetailPlan(command.getDetailPlanId(), command.getPlanId());
         Long currentUserId = getCurrentUserId();
 
-        validateWeekPassed(detailPlan.getParticipantInfo().getRoomId(), detailPlan.getPlanId());
+        validateWeekPassed(detailPlan.getPlanId());
         if (!Objects.equals(currentUserId, detailPlan.getParticipantInfo().getUserId())) {
             throw new GotBetterException(MessageType.FORBIDDEN);
-        }
-        if (detailPlan.getRejected()) {
-            detailPlanRepository.updateRejected(detailPlan.getDetailPlanId(), false);
         }
         if (detailPlan.getComplete()) {
             throw new GotBetterException(MessageType.CONFLICT);
         }
-        detailPlanRepository.updateDetailPlanCompleted(
-                detailPlan.getDetailPlanId(), command.getApproveComment());
-        List<DetailPlanEval> detailPlanEvals = detailPlanEvalRepository.findByDetailPlanEvalIdDetailPlanId(detailPlan.getDetailPlanId());
+        if (detailPlan.getRejected()) {
+            detailPlan.updateRejected(false);
+        }
+        detailPlan.updateDetailPlanCompleted(command.getApproveComment());
+        detailPlanRepository.save(detailPlan);
+
+        Integer detailPlanEvalSize = detailPlanEvalRepository.countByDetailPlanEvalIdDetailPlanId(detailPlan.getDetailPlanId());
+
         return DetailPlanReadUseCase.FindDetailPlanResult
-                .findByDetailPlanEval(detailPlan, command.getApproveComment(), true
-                        , detailPlanEvals.size(), false);
+            .findByDetailPlan(detailPlan, detailPlanEvalSize, false);
     }
 
     @Override
@@ -66,7 +63,7 @@ public class DetailPlanCompleteService implements DetailPlanCompleteOperationUse
         DetailPlan detailPlan = validateDetailPlan(command.getDetailPlanId(), command.getPlanId());
         Long currentUserId = getCurrentUserId();
 
-        validateWeekPassed(detailPlan.getParticipantInfo().getRoomId(), detailPlan.getPlanId());
+        validateWeekPassed(detailPlan.getPlanId());
         if (!Objects.equals(currentUserId, detailPlan.getParticipantInfo().getUserId())
         || detailPlan.getRejected()) {
             throw new GotBetterException(MessageType.FORBIDDEN);
@@ -74,12 +71,14 @@ public class DetailPlanCompleteService implements DetailPlanCompleteOperationUse
         if (!detailPlan.getComplete()) {
             throw new GotBetterException(MessageType.CONFLICT);
         }
-        detailPlanRepository.updateDetailPlanUndo(detailPlan.getDetailPlanId(), false);
+        detailPlan.updateDetailPlanUndo(false);
+        detailPlanRepository.save(detailPlan);
         detailPlanEvalRepository.deleteByDetailPlanEvalIdDetailPlanId(detailPlan.getDetailPlanId());
-        List<DetailPlanEval> detailPlanEvals = detailPlanEvalRepository.findByDetailPlanEvalIdDetailPlanId(detailPlan.getDetailPlanId());
+
+        Integer detailPlanEvalSize = detailPlanEvalRepository.countByDetailPlanEvalIdDetailPlanId(detailPlan.getDetailPlanId());
+
         return DetailPlanReadUseCase.FindDetailPlanResult
-                .findByDetailPlanEval(detailPlan, "", false
-                        , detailPlanEvals.size(), false);
+                .findByDetailPlan(detailPlan, detailPlanEvalSize, false);
     }
 
     /**
@@ -87,6 +86,7 @@ public class DetailPlanCompleteService implements DetailPlanCompleteOperationUse
      */
     private DetailPlan validateDetailPlan(Long detailPlanId, Long planId) {
         DetailPlan detailPlan = detailPlanRepository.findByDetailPlanId(detailPlanId);
+
         if (detailPlan == null) {
             throw new GotBetterException(MessageType.NOT_FOUND);
         }
@@ -96,13 +96,15 @@ public class DetailPlanCompleteService implements DetailPlanCompleteOperationUse
         return detailPlan;
     }
 
-    private void validateWeekPassed(Long roomId, Long planId) {
-        Room room = roomRepository.findByRoomId(roomId).orElseThrow(() -> {
+    private void validateWeekPassed(Long planId) {
+        PlanDto planDto = planRepository.findPlanJoinRoom(planId);
+
+        if (planDto == null) {
             throw new GotBetterException(MessageType.NOT_FOUND);
-        });
-        Plan plan = planRepository.findByPlanId(planId).orElseThrow(() -> {
-            throw new GotBetterException(MessageType.NOT_FOUND);
-        });
+        }
+
+        Plan plan = planDto.getPlan();
+        Room room = planDto.getRoom();
 
         if (!Objects.equals(room.getCurrentWeek(), plan.getWeek())) {
             throw new GotBetterException(MessageType.FORBIDDEN_DATE);

--- a/gotbetter/src/main/java/pcrc/gotbetter/detail_plan/service/DetailPlanReadUseCase.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/detail_plan/service/DetailPlanReadUseCase.java
@@ -41,20 +41,5 @@ public interface DetailPlanReadUseCase {
                     .detailPlanDislikeChecked(checked)
                     .build();
         }
-
-        public static FindDetailPlanResult findByDetailPlanEval(DetailPlan detailPlan,
-                                                                String approveComment, Boolean complete,
-                                                                Integer dislikeCount, Boolean checked) {
-            return FindDetailPlanResult.builder()
-                    .detailPlanId(detailPlan.getDetailPlanId())
-                    .content(detailPlan.getContent())
-                    .complete(complete)
-                    .approveComment(approveComment)
-                    .rejected(false)
-                    .planId(detailPlan.getPlanId())
-                    .detailPlanDislikeCount(dislikeCount)
-                    .detailPlanDislikeChecked(checked)
-                    .build();
-        }
     }
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/detail_plan_evaluation/data_access/repository/DetailPlanEvalQueryRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/detail_plan_evaluation/data_access/repository/DetailPlanEvalQueryRepository.java
@@ -1,9 +1,7 @@
 package pcrc.gotbetter.detail_plan_evaluation.data_access.repository;
 
 public interface DetailPlanEvalQueryRepository {
-    // insert, update, delete
-    void deleteDetailPlanEval(Long detailPlanId, Long participantId);
 
-    // select
     Boolean existsEval(Long detailPlanId, Long participantId);
+
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/detail_plan_evaluation/data_access/repository/DetailPlanEvalRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/detail_plan_evaluation/data_access/repository/DetailPlanEvalRepository.java
@@ -11,5 +11,10 @@ import java.util.List;
 public interface DetailPlanEvalRepository
         extends JpaRepository<DetailPlanEval, DetailPlanEvalId>, DetailPlanEvalQueryRepository {
     List<DetailPlanEval> findByDetailPlanEvalIdDetailPlanId(Long detailPlanId);
+
+    Integer countByDetailPlanEvalIdDetailPlanId(Long detailPlanId);
+
     void deleteByDetailPlanEvalIdDetailPlanId(Long detailPlanId);
+
+    void deleteByDetailPlanEvalId(DetailPlanEvalId detailPlanEvalId);
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/detail_plan_evaluation/data_access/repository/DetailPlanEvalRepositoryImpl.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/detail_plan_evaluation/data_access/repository/DetailPlanEvalRepositoryImpl.java
@@ -2,7 +2,6 @@ package pcrc.gotbetter.detail_plan_evaluation.data_access.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import org.springframework.transaction.annotation.Transactional;
 
 import static pcrc.gotbetter.detail_plan_evaluation.data_access.entity.QDetailPlanEval.detailPlanEval;
 
@@ -11,15 +10,6 @@ public class DetailPlanEvalRepositoryImpl implements DetailPlanEvalQueryReposito
 
     public DetailPlanEvalRepositoryImpl(JPAQueryFactory queryFactory) {
         this.queryFactory = queryFactory;
-    }
-
-    @Override
-    @Transactional
-    public void deleteDetailPlanEval(Long detailPlanId, Long participantId) {
-        queryFactory.delete(detailPlanEval)
-                .where(detailPlanEvalEqDetailPlanId(detailPlanId),
-                        detailPlanEvalEqParticipantId(participantId))
-                .execute();
     }
 
     @Override

--- a/gotbetter/src/main/java/pcrc/gotbetter/detail_plan_evaluation/service/DetailPlanEvalOperationUseCase.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/detail_plan_evaluation/service/DetailPlanEvalOperationUseCase.java
@@ -6,8 +6,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 public interface DetailPlanEvalOperationUseCase {
-    DetailPlanEvalReadUseCase.FindDetailPlanEvalResult createDetailPlanEvaluation(DetailPlanEvaluationCommand command)
-        throws InterruptedException;
+    DetailPlanEvalReadUseCase.FindDetailPlanEvalResult createDetailPlanEvaluation(DetailPlanEvaluationCommand command);
     DetailPlanEvalReadUseCase.FindDetailPlanEvalResult deleteDetailPlanEvaluation(DetailPlanEvaluationCommand command);
 
     @EqualsAndHashCode(callSuper = false)

--- a/gotbetter/src/main/java/pcrc/gotbetter/detail_plan_evaluation/service/DetailPlanEvalReadUseCase.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/detail_plan_evaluation/service/DetailPlanEvalReadUseCase.java
@@ -21,11 +21,16 @@ public interface DetailPlanEvalReadUseCase {
 
         public static FindDetailPlanEvalResult findByDetailPlanEval(DetailPlan detailPlan,
                                                                     Integer dislikeCount, Boolean checked) {
+            String comment = detailPlan.getApproveComment();
+            if (comment == null) {
+                comment = "";
+            }
+
             return FindDetailPlanEvalResult.builder()
                     .detailPlanId(detailPlan.getDetailPlanId())
                     .content(detailPlan.getContent())
                     .complete(detailPlan.getComplete())
-                    .approveComment(detailPlan.getApproveComment())
+                    .approveComment(comment)
                     .rejected(detailPlan.getRejected())
                     .planId(detailPlan.getPlanId())
                     .detailPlanDislikeCount(dislikeCount)

--- a/gotbetter/src/main/java/pcrc/gotbetter/detail_plan_evaluation/service/DetailPlanEvalService.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/detail_plan_evaluation/service/DetailPlanEvalService.java
@@ -8,18 +8,16 @@ import pcrc.gotbetter.detail_plan.data_access.repository.DetailPlanRepository;
 import pcrc.gotbetter.detail_plan_evaluation.data_access.entity.DetailPlanEval;
 import pcrc.gotbetter.detail_plan_evaluation.data_access.entity.DetailPlanEvalId;
 import pcrc.gotbetter.detail_plan_evaluation.data_access.repository.DetailPlanEvalRepository;
-import pcrc.gotbetter.participant.data_access.repository.ViewRepository;
-import pcrc.gotbetter.participant.data_access.view.EnteredView;
+import pcrc.gotbetter.participant.data_access.entity.Participant;
+import pcrc.gotbetter.participant.data_access.repository.ParticipantRepository;
+import pcrc.gotbetter.plan.data_access.dto.PlanDto;
 import pcrc.gotbetter.plan.data_access.entity.Plan;
 import pcrc.gotbetter.plan.data_access.repository.PlanRepository;
 import pcrc.gotbetter.room.data_access.entity.Room;
-import pcrc.gotbetter.room.data_access.repository.RoomRepository;
 import pcrc.gotbetter.setting.http_api.GotBetterException;
 import pcrc.gotbetter.setting.http_api.MessageType;
 
 import java.time.LocalDate;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Objects;
 
 import static pcrc.gotbetter.setting.security.SecurityUtil.getCurrentUserId;
@@ -28,80 +26,74 @@ import static pcrc.gotbetter.setting.security.SecurityUtil.getCurrentUserId;
 public class DetailPlanEvalService implements DetailPlanEvalOperationUseCase {
     private final DetailPlanEvalRepository detailPlanEvalRepository;
     private final DetailPlanRepository detailPlanRepository;
-    private final RoomRepository roomRepository;
     private final PlanRepository planRepository;
-    private final ViewRepository viewRepository;
+    private final ParticipantRepository participantRepository;
 
     @Autowired
     public DetailPlanEvalService(DetailPlanEvalRepository detailPlanEvalRepository,
                                  DetailPlanRepository detailPlanRepository,
-                                 RoomRepository roomRepository,
-                                 PlanRepository planRepository, ViewRepository viewRepository) {
+                                 PlanRepository planRepository,
+                                 ParticipantRepository participantRepository) {
         this.detailPlanEvalRepository = detailPlanEvalRepository;
         this.detailPlanRepository = detailPlanRepository;
-        this.roomRepository = roomRepository;
         this.planRepository = planRepository;
-        this.viewRepository = viewRepository;
+        this.participantRepository = participantRepository;
     }
 
     @Override
     @Transactional
-    public DetailPlanEvalReadUseCase.FindDetailPlanEvalResult createDetailPlanEvaluation(DetailPlanEvaluationCommand command) throws InterruptedException {
+    public DetailPlanEvalReadUseCase.FindDetailPlanEvalResult createDetailPlanEvaluation(DetailPlanEvaluationCommand command) {
         DetailPlan detailPlan = validateDetailPlan(command.getDetailPlanId());
-        EnteredView enteredView = validateEnteredView(detailPlan.getParticipantInfo().getRoomId());
+        PlanDto planDto = validatePlanRoom(detailPlan.getPlanId());
+        Participant evaluator = validateCanEvaluate(planDto, detailPlan);
+        Room room = planDto.getRoom();
+        Integer detailPlanEvalSize = detailPlanEvalRepository.countByDetailPlanEvalIdDetailPlanId(command.getDetailPlanId());
+        boolean checked = false;
 
-        validateWeekPassed(enteredView.getRoomId(),detailPlan.getPlanId());
-        if (detailPlan.getRejected()) {
-            throw new GotBetterException(MessageType.FORBIDDEN);
-        }
-        if (!detailPlan.getComplete()) {
-            throw new GotBetterException(MessageType.FORBIDDEN);
-        }
-        if (detailPlanEvalRepository.existsEval(detailPlan.getDetailPlanId(), enteredView.getParticipantId())) {
-            throw new GotBetterException(MessageType.CONFLICT);
-        }
-
-        List<DetailPlanEval> detailPlanEvals = detailPlanEvalRepository
-                .findByDetailPlanEvalIdDetailPlanId(command.getDetailPlanId());
-        if (Math.floor(enteredView.getCurrentUserNum() - 1) / 2 < detailPlanEvals.size() + 1) {
-            detailPlanRepository.updateDetailPlanUndo(detailPlan.getDetailPlanId(), true);
+        if (Math.floor(room.getCurrentUserNum() - 1) / 2 < detailPlanEvalSize + 1) {
+            detailPlan.updateDetailPlanUndo(true);
+            detailPlanRepository.save(detailPlan);
             detailPlanEvalRepository.deleteByDetailPlanEvalIdDetailPlanId(detailPlan.getDetailPlanId());
-            // 여기 수정해야 함.
-            HashMap<String, Object> data = detail_dislike_data(enteredView.getUserId(), command.getDetailPlanId());
-            Thread.sleep(1000);
-            DetailPlan d = validateDetailPlan(command.getDetailPlanId());
-            System.out.println(d.getDetailPlanId() + ' ' + d.getContent() + ' ' + d.getComplete() + ' ' + d.getApproveComment() + ' ' + d.getRejected());
-            return DetailPlanEvalReadUseCase.FindDetailPlanEvalResult.findByDetailPlanEval(
-                    validateDetailPlan(command.getDetailPlanId()),
-                    (Integer) data.get("detail_dislike_cnt"), (Boolean) data.get("detail_dislike_checked"));
+            detailPlanEvalSize = 0;
         } else {
             DetailPlanEval detailPlanEval = DetailPlanEval.builder()
-                    .detailPlanEvalId(DetailPlanEvalId.builder()
-                            .detailPlanId(detailPlan.getDetailPlanId())
-                            .planId(detailPlan.getPlanId())
-                            .participantId(enteredView.getParticipantId())
-                            .userId(enteredView.getUserId())
-                            .roomId(enteredView.getRoomId())
-                            .build())
-                    .build();
+                .detailPlanEvalId(DetailPlanEvalId.builder()
+                    .detailPlanId(detailPlan.getDetailPlanId())
+                    .planId(detailPlan.getPlanId())
+                    .participantId(evaluator.getParticipantId())
+                    .userId(evaluator.getUserId())
+                    .roomId(evaluator.getRoomId())
+                    .build())
+                .build();
             detailPlanEvalRepository.save(detailPlanEval);
-            HashMap<String, Object> data = detail_dislike_data(enteredView.getUserId(), command.getDetailPlanId());
-            return DetailPlanEvalReadUseCase.FindDetailPlanEvalResult.findByDetailPlanEval(detailPlan
-                    , (Integer) data.get("detail_dislike_cnt"), (Boolean) data.get("detail_dislike_checked"));
+            checked = true;
+            detailPlanEvalSize = detailPlanEvalSize + 1;
         }
+        return DetailPlanEvalReadUseCase.FindDetailPlanEvalResult.findByDetailPlanEval(detailPlan
+            , detailPlanEvalSize, checked);
     }
 
     @Override
+    @Transactional
     public DetailPlanEvalReadUseCase.FindDetailPlanEvalResult deleteDetailPlanEvaluation(DetailPlanEvaluationCommand command) {
         DetailPlan detailPlan = validateDetailPlan(command.getDetailPlanId());
-        EnteredView enteredView = validateEnteredView(detailPlan.getParticipantInfo().getRoomId());
+        PlanDto planDto = validatePlanRoom(detailPlan.getPlanId());
+        Participant participant = validateUserInRoom(detailPlan.getParticipantInfo().getRoomId());
 
-        validateWeekPassed(enteredView.getRoomId(),detailPlan.getPlanId());
-        if (detailPlanEvalRepository.existsEval(detailPlan.getDetailPlanId(), enteredView.getParticipantId())) {
-            detailPlanEvalRepository.deleteDetailPlanEval(detailPlan.getDetailPlanId(), enteredView.getParticipantId());
-            HashMap<String, Object> data = detail_dislike_data(enteredView.getUserId(), command.getDetailPlanId());
-            return DetailPlanEvalReadUseCase.FindDetailPlanEvalResult.findByDetailPlanEval(detailPlan
-                    , (Integer) data.get("detail_dislike_cnt"), (Boolean) data.get("detail_dislike_checked"));
+        validateWeekPassed(planDto);
+        if (detailPlanEvalRepository.existsEval(detailPlan.getDetailPlanId(), participant.getParticipantId())) {
+            detailPlanEvalRepository.deleteByDetailPlanEvalId(DetailPlanEvalId.builder()
+                    .detailPlanId(detailPlan.getDetailPlanId())
+                    .planId(detailPlan.getPlanId())
+                    .participantId(participant.getParticipantId())
+                    .userId(participant.getUserId())
+                    .roomId(participant.getRoomId())
+                .build());
+
+            Integer detailPlanEvalSize = detailPlanEvalRepository.countByDetailPlanEvalIdDetailPlanId(command.getDetailPlanId());
+
+            return DetailPlanEvalReadUseCase.FindDetailPlanEvalResult.findByDetailPlanEval(
+                detailPlan, detailPlanEvalSize, false);
         }
         throw new GotBetterException(MessageType.NOT_FOUND);
     }
@@ -111,55 +103,66 @@ public class DetailPlanEvalService implements DetailPlanEvalOperationUseCase {
      */
     private DetailPlan validateDetailPlan(Long detailPlanId) {
         DetailPlan detailPlan = detailPlanRepository.findByDetailPlanId(detailPlanId);
+
         if (detailPlan == null) {
             throw new GotBetterException(MessageType.NOT_FOUND);
         }
         return detailPlan;
     }
 
-    private EnteredView validateEnteredView(Long roomId) {
-        EnteredView enteredView = viewRepository.enteredByUserIdRoomId(getCurrentUserId(), roomId);
+    private PlanDto validatePlanRoom(Long planId) {
+        PlanDto planDto = planRepository.findPlanJoinRoom(planId);
 
-        if (enteredView == null) {
+        if (planDto == null) {
             throw new GotBetterException(MessageType.NOT_FOUND);
         }
-        return enteredView;
+        return planDto;
     }
 
-    private void validateWeekPassed(Long roomId, Long planId) {
-        Room room = roomRepository.findByRoomId(roomId).orElseThrow(() -> {
+    private Participant validateCanEvaluate (PlanDto planDto, DetailPlan detailPlan) {
+        Room roomInfo = planDto.getRoom();
+        Participant evaluator = validateUserInRoom(roomInfo.getRoomId());
+
+        // 자기 자신
+        if (Objects.equals(detailPlan.getParticipantInfo().getUserId(), getCurrentUserId())) {
+            throw new GotBetterException(MessageType.FORBIDDEN);
+        }
+        validateWeekPassed(planDto);
+        if (detailPlan.getRejected()) {
+            throw new GotBetterException(MessageType.FORBIDDEN);
+        }
+        if (!detailPlan.getComplete()) {
+            throw new GotBetterException(MessageType.FORBIDDEN);
+        }
+        if (detailPlanEvalRepository.existsEval(detailPlan.getDetailPlanId(), evaluator.getParticipantId())) {
+            throw new GotBetterException(MessageType.CONFLICT);
+        }
+        return evaluator;
+    }
+
+    private Participant validateUserInRoom(Long roomId) {
+        Participant participant = participantRepository.findByUserIdAndRoomId(getCurrentUserId(), roomId);
+
+        if (participant == null) {
             throw new GotBetterException(MessageType.NOT_FOUND);
-        });
-        Plan plan = planRepository.findByPlanId(planId).orElseThrow(() -> {
-            throw new GotBetterException(MessageType.NOT_FOUND);
-        });
+        }
+        return participant;
+    }
+
+    private void validateWeekPassed(PlanDto planDto) {
+        Plan plan = planDto.getPlan();
+        Room room = planDto.getRoom();
+
         if (!Objects.equals(room.getCurrentWeek(), plan.getWeek())) {
             throw new GotBetterException(MessageType.FORBIDDEN_DATE);
         } else {
             if (plan.getStartDate().isAfter(LocalDate.now())
-                    || plan.getTargetDate().isBefore(LocalDate.now())) {
+                || plan.getTargetDate().isBefore(LocalDate.now())) {
                 throw new GotBetterException(MessageType.FORBIDDEN_DATE);
             }
         }
-//        if (!plan.getThreeDaysPassed()) {
-//            throw new GotBetterException(MessageType.FORBIDDEN_DATE);
-//        }
-    }
-
-    private HashMap<String, Object> detail_dislike_data(Long userId, Long detailPlanId) {
-        List<DetailPlanEval> detailPlanEvals = detailPlanEvalRepository
-                .findByDetailPlanEvalIdDetailPlanId(detailPlanId);
-        boolean checked = false;
-        HashMap<String, Object> data = new HashMap<>();
-
-        for (DetailPlanEval de : detailPlanEvals) {
-            if (Objects.equals(de.getDetailPlanEvalId().getUserId(), userId)) {
-                checked = true;
-                break;
-            }
-        }
-        data.put("detail_dislike_cnt", detailPlanEvals.size());
-        data.put("detail_dislike_checked", checked);
-        return data;
+        //        if (!plan.getThreeDaysPassed()) {
+        //            throw new GotBetterException(MessageType.FORBIDDEN_DATE);
+        //        }
     }
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/detail_plan_evaluation/ui/controller/DetailPlanEvalController.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/detail_plan_evaluation/ui/controller/DetailPlanEvalController.java
@@ -21,7 +21,7 @@ public class DetailPlanEvalController {
     }
 
     @PostMapping(value = "")
-    public ResponseEntity<DetailPlanEvaluationView> createDetailPlanEvaluation(@PathVariable(value = "detail_plan_id") Long detail_plan_id) throws InterruptedException {
+    public ResponseEntity<DetailPlanEvaluationView> createDetailPlanEvaluation(@PathVariable(value = "detail_plan_id") Long detail_plan_id) {
 
         log.info("\"CREATE A DETAIL PLAN DISLIKE\"");
 

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantQueryRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantQueryRepository.java
@@ -6,8 +6,8 @@ import pcrc.gotbetter.participant.data_access.dto.ParticipantDto;
 import pcrc.gotbetter.participant.data_access.entity.Participant;
 
 public interface ParticipantQueryRepository {
-    void updatePercentSum(Long participantId, Float percent); // batchconfig
-    void updateRefund(Long participantId, Integer refund); // batchconfig
+    void updatePercentSum(Long participantId, Float percent); /** Todo batchconfig */
+    void updateRefund(Long participantId, Integer refund); /** Todo batchconfig */
 
     Boolean isMatchedLeader(Long userId, Long roomId);
 
@@ -17,5 +17,5 @@ public interface ParticipantQueryRepository {
 
     List<ParticipantDto> findUserInfoList(Long roomId);
 
-    ParticipantDto findRoom(Long participantId);
+    ParticipantDto findParticipantRoom(Long participantId);
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantRepositoryImpl.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantRepositoryImpl.java
@@ -89,7 +89,7 @@ public class ParticipantRepositoryImpl implements ParticipantQueryRepository {
     }
 
     @Override
-    public ParticipantDto findRoom(Long participantId) {
+    public ParticipantDto findParticipantRoom(Long participantId) {
         return queryFactory
             .select(Projections.constructor(ParticipantDto.class,
                 participant, room))

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ViewRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ViewRepository.java
@@ -23,14 +23,6 @@ public class ViewRepository {
                 .fetchFirst();
     }
 
-    public EnteredView enteredByUserIdRoomId(Long userId, Long roomId) {
-        return queryFactory
-                .selectFrom(enteredView)
-                .where(enteredView.userId.eq(userId),
-                        enteredView.roomId.eq(roomId))
-                .fetchFirst();
-    }
-
     public List<EnteredView> enteredListByRoomId(Long roomId) {
         return queryFactory
                 .selectFrom(enteredView)

--- a/gotbetter/src/main/java/pcrc/gotbetter/plan/data_access/repository/PlanQueryRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/plan/data_access/repository/PlanQueryRepository.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 public interface PlanQueryRepository {
     // insert, update, delete
-    void updateRejected(Long planId, Boolean change);
     void updateThreeDaysPassed(Long planId);
 
     // select

--- a/gotbetter/src/main/java/pcrc/gotbetter/plan/data_access/repository/PlanRepositoryImpl.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/plan/data_access/repository/PlanRepositoryImpl.java
@@ -27,16 +27,6 @@ public class PlanRepositoryImpl implements PlanQueryRepository {
 
     @Override
     @Transactional
-    public void updateRejected(Long planId, Boolean change) {
-        queryFactory
-                .update(plan)
-                .set(plan.rejected, change)
-                .where(eqPlanId(planId))
-                .execute();
-    }
-
-    @Override
-    @Transactional
     public void updateThreeDaysPassed(Long planId) {
         queryFactory
                 .update(plan)

--- a/gotbetter/src/main/java/pcrc/gotbetter/plan/service/PlanService.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/plan/service/PlanService.java
@@ -89,7 +89,7 @@ public class PlanService implements PlanOperationUseCase, PlanReadUseCase {
      * validate
      */
     private ParticipantDto validateParticipantRoom(Long participantId) {
-        ParticipantDto participantDto = participantRepository.findRoom(participantId);
+        ParticipantDto participantDto = participantRepository.findParticipantRoom(participantId);
 
         if (participantDto == null) {
             throw new GotBetterException(MessageType.NOT_FOUND);


### PR DESCRIPTION
…ydsl 구분하면서 뷰 테이블 사용 없앰

## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #127 
<br/>

## ⚙️ 변경 사항 

DetailPlan, DetailPlanEvaluation 도메인 spring data jpa와 querydsl 구분하면서 뷰 테이블 사용 없앰

- spring data jpa는 CRUD 실행할 때 주로 사용하고,  querydsl은 복잡한 쿼리를 실행할 때 사용하는 방향으로 수정
- 뷰 테이블을 이용한 쿼리를 querydsl을 사용한 엔티티 조인을 활용한 쿼리 실행으로 수정

<br/>

## 💦 변경한 이유

- spring data jpa와 querydsl 구분을 통해 효율적으로 쿼리를 실행

<br/>

## 💻 테스트 사항

- postman

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
