### PR TITLE
[refactor] Participant 도메인의 뷰 테이블 사용을 querydsl 엔티티 조인으로 수정

### DIFF
--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantQueryRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantQueryRepository.java
@@ -17,5 +17,6 @@ public interface ParticipantQueryRepository {
 
     List<ParticipantDto> findUserInfoList(Long roomId);
 
+    // join
     ParticipantDto findParticipantRoom(Long participantId);
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ViewRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ViewRepository.java
@@ -16,13 +16,6 @@ public class ViewRepository {
         this.queryFactory = queryFactory;
     }
 
-    public EnteredView enteredByParticipantId(Long participantId) {
-        return queryFactory
-                .selectFrom(enteredView)
-                .where(enteredView.participantId.eq(participantId))
-                .fetchFirst();
-    }
-
     public List<EnteredView> enteredListByRoomId(Long roomId) {
         return queryFactory
                 .selectFrom(enteredView)


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #125 
<br/>

## ⚙️ 변경 사항 

Participant 도메인의 뷰 테이블 사용을 querydsl 엔티티 조인으로 수정

<br/>

## 💦 변경한 이유

- 뷰 테이블의 불필요한 사용을 없애기 위함.

<br/>

## 💻 테스트 사항

- postman

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
