### PR TITLE
[refactor] BatchConfig의 CRUD 쿼리를 jpa 사용으로 수정하고 뷰 테이블 사용 없앰

### DIFF
--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/entity/Participant.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/entity/Participant.java
@@ -42,4 +42,12 @@ public class Participant extends BaseTimeEntity {
         this.percentSum = percentSum;
         this.refund = refund;
     }
+
+    public void updatePercentSum(Float percentSum) {
+        this.percentSum += percentSum;
+    }
+
+    public void updateRefund(Integer refund) {
+        this.refund = refund;
+    }
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantQueryRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantQueryRepository.java
@@ -6,8 +6,6 @@ import pcrc.gotbetter.participant.data_access.dto.ParticipantDto;
 import pcrc.gotbetter.participant.data_access.entity.Participant;
 
 public interface ParticipantQueryRepository {
-    void updatePercentSum(Long participantId, Float percent); /** Todo batchconfig */
-    void updateRefund(Long participantId, Integer refund); /** Todo batchconfig */
 
     Boolean isMatchedLeader(Long userId, Long roomId);
 
@@ -18,5 +16,8 @@ public interface ParticipantQueryRepository {
     List<ParticipantDto> findUserInfoList(Long roomId);
 
     // join
-    ParticipantDto findParticipantRoom(Long participantId);
+    ParticipantDto findParticipantRoomByParticipantId(Long participantId);
+
+    List<ParticipantDto> findParticipantRoomByRoomId(Long roomId);
+
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantRepositoryImpl.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/data_access/repository/ParticipantRepositoryImpl.java
@@ -3,7 +3,6 @@ package pcrc.gotbetter.participant.data_access.repository;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import org.springframework.transaction.annotation.Transactional;
 
 import static pcrc.gotbetter.participant.data_access.entity.QParticipant.participant;
 import static pcrc.gotbetter.room.data_access.entity.QRoom.*;
@@ -21,26 +20,6 @@ public class ParticipantRepositoryImpl implements ParticipantQueryRepository {
 
     public ParticipantRepositoryImpl(JPAQueryFactory queryFactory) {
         this.queryFactory = queryFactory;
-    }
-
-    @Override
-    @Transactional
-    public void updatePercentSum(Long participantId, Float percent) {
-        queryFactory
-                .update(participant)
-                .where(participantEqParticipantId(participantId))
-                .set(participant.percentSum, participant.percentSum.add(percent))
-                .execute();
-    }
-
-    @Override
-    @Transactional
-    public void updateRefund(Long participantId, Integer refund) {
-        queryFactory
-                .update(participant)
-                .where(participantEqParticipantId(participantId))
-                .set(participant.refund, refund)
-                .execute();
     }
 
     @Override
@@ -89,7 +68,7 @@ public class ParticipantRepositoryImpl implements ParticipantQueryRepository {
     }
 
     @Override
-    public ParticipantDto findParticipantRoom(Long participantId) {
+    public ParticipantDto findParticipantRoomByParticipantId(Long participantId) {
         return queryFactory
             .select(Projections.constructor(ParticipantDto.class,
                 participant, room))
@@ -97,6 +76,17 @@ public class ParticipantRepositoryImpl implements ParticipantQueryRepository {
             .leftJoin(room).on(participant.roomId.eq(room.roomId)).fetchJoin()
             .where(participantEqParticipantId(participantId))
             .fetchFirst();
+    }
+
+    @Override
+    public List<ParticipantDto> findParticipantRoomByRoomId(Long roomId) {
+        return queryFactory
+            .select(Projections.constructor(ParticipantDto.class,
+                participant, room))
+            .from(participant)
+            .leftJoin(room).on(participant.roomId.eq(room.roomId)).fetchJoin()
+            .where(participantEqRoomId(roomId))
+            .fetch();
     }
 
     /**

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/service/ParticipantService.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/service/ParticipantService.java
@@ -120,7 +120,7 @@ public class ParticipantService implements ParticipantOperationUseCase, Particip
 
     @Override
     public Integer getMyRefund(Long participantId) { // 마지막 주차 끝난 후 조회 가능
-        ParticipantDto participantDto = participantRepository.findParticipantRoom(participantId);
+        ParticipantDto participantDto = participantRepository.findParticipantRoomByParticipantId(participantId);
 
         // 방의 멤버인지 확인
         if (participantDto == null || !Objects.equals(participantDto.getParticipant().getUserId(), getCurrentUserId())) {

--- a/gotbetter/src/main/java/pcrc/gotbetter/plan/data_access/dto/PlanDto.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/plan/data_access/dto/PlanDto.java
@@ -2,6 +2,7 @@ package pcrc.gotbetter.plan.data_access.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import pcrc.gotbetter.participant.data_access.entity.Participant;
 import pcrc.gotbetter.plan.data_access.entity.Plan;
 import pcrc.gotbetter.room.data_access.entity.Room;
 
@@ -10,4 +11,15 @@ import pcrc.gotbetter.room.data_access.entity.Room;
 public class PlanDto {
 	private Plan plan;
 	private Room room;
+	private Participant participant;
+
+	public PlanDto(Plan plan, Room room) {
+		this.plan = plan;
+		this.room = room;
+	}
+
+	public PlanDto(Plan plan, Participant participant) {
+		this.plan = plan;
+		this.participant = participant;
+	}
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/plan/data_access/entity/Plan.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/plan/data_access/entity/Plan.java
@@ -54,4 +54,8 @@ public class Plan extends BaseTimeEntity {
     public void updateRejected(Boolean rejected) {
         this.rejected = rejected;
     }
+
+    public void updateThreeDaysPassed() {
+        this.threeDaysPassed = true;
+    }
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/plan/data_access/repository/PlanQueryRepository.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/plan/data_access/repository/PlanQueryRepository.java
@@ -7,15 +7,16 @@ import java.util.HashMap;
 import java.util.List;
 
 public interface PlanQueryRepository {
-    // insert, update, delete
-    void updateThreeDaysPassed(Long planId);
 
-    // select
     Plan findWeekPlanOfUser(Long participantId, Integer week);
+
     Boolean existsByParticipantId(Long participantId);
-    List<Plan> findListByRoomId(Long roomId, Integer passedWeek);
+
     List<HashMap<String, Object>> findPushNotification();
 
     // join
     PlanDto findPlanJoinRoom(Long planId);
+
+    List<PlanDto> findPlanJoinParticipant(Long roomId, Integer passedWeek);
+
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/plan/service/PlanService.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/plan/service/PlanService.java
@@ -89,7 +89,7 @@ public class PlanService implements PlanOperationUseCase, PlanReadUseCase {
      * validate
      */
     private ParticipantDto validateParticipantRoom(Long participantId) {
-        ParticipantDto participantDto = participantRepository.findParticipantRoom(participantId);
+        ParticipantDto participantDto = participantRepository.findParticipantRoomByParticipantId(participantId);
 
         if (participantDto == null) {
             throw new GotBetterException(MessageType.NOT_FOUND);


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #146 
<br/>

## ⚙️ 변경 사항 

BatchConfig의 CRUD 쿼리를 jpa 사용으로 수정하고 뷰 테이블 사용 없앰

<br/>

## 💦 변경한 이유

- jpa의 영속성을 고려하여 querydsl의 CRUD 사용을 자제함

<br/>

## 💻 테스트 사항

- 어떻게 테스트를 실행했는지 작성

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
