### PR TITLE
[bug] 사진과 텍스트 분리하여 받는 부분을 하나의 dto로 수정

### DIFF
--- a/gotbetter/src/main/java/pcrc/gotbetter/detail_plan_record/ui/controller/DetailPlanRecordController.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/detail_plan_record/ui/controller/DetailPlanRecordController.java
@@ -9,15 +9,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +23,8 @@ import pcrc.gotbetter.detail_plan_record.service.DetailPlanRecordOperationUseCas
 import pcrc.gotbetter.detail_plan_record.service.DetailPlanRecordReadUseCase;
 import pcrc.gotbetter.detail_plan_record.ui.request_body.DetailPlanRecordRequest;
 import pcrc.gotbetter.detail_plan_record.ui.view.DetailPlanRecordView;
+import pcrc.gotbetter.setting.http_api.GotBetterException;
+import pcrc.gotbetter.setting.http_api.MessageType;
 
 @Slf4j
 @RestController
@@ -44,17 +44,20 @@ public class DetailPlanRecordController {
 	@PostMapping(value = "")
 	public ResponseEntity<DetailPlanRecordView> createRecord(
 		@PathVariable(value = "detail_plan_id") Long detail_plan_id,
-		@Valid @RequestPart(value = "record_content") DetailPlanRecordRequest request,
-		@RequestParam MultipartFile record_photo
+		@Valid @ModelAttribute DetailPlanRecordRequest request
 	) throws IOException {
 
 		log.info("\"CREATE A DETAIL PLAN RECORD\"");
+
+		if (request.getRecord_photo().isEmpty()) {
+			throw new GotBetterException(MessageType.BAD_REQUEST);
+		}
 
 		var command = DetailPlanRecordOperationUseCase.DetailPlanRecordCreateCommand.builder()
 			.detailPlanId(detail_plan_id)
 			.recordTitle(request.getRecord_title())
 			.recordBody(request.getRecord_body())
-			.recordPhoto(record_photo)
+			.recordPhoto(request.getRecord_photo())
 			.build();
 		DetailPlanRecordReadUseCase.FindDetailPlanRecordResult result = detailPlanRecordOperationUseCase.createRecord(
 			command);
@@ -83,18 +86,21 @@ public class DetailPlanRecordController {
 	public ResponseEntity<DetailPlanRecordView> updateRecord(
 		@PathVariable(value = "detail_plan_id") Long detail_plan_id,
 		@PathVariable(value = "record_id") Long record_id,
-		@Valid @RequestPart(value = "record_content") DetailPlanRecordRequest request,
-		@RequestParam MultipartFile record_photo
+		@Valid @ModelAttribute DetailPlanRecordRequest request
 	) {
 
 		log.info("\"UPDATE THE DETAIL PLAN RECORD\"");
+
+		if (request.getRecord_photo().isEmpty()) {
+			throw new GotBetterException(MessageType.BAD_REQUEST);
+		}
 
 		var command = DetailPlanRecordOperationUseCase.DetailPlanRecordUpdateCommand.builder()
 			.detailPlanId(detail_plan_id)
 			.recordId(record_id)
 			.recordTitle(request.getRecord_title())
 			.recordBody(request.getRecord_body())
-			.recordPhoto(record_photo)
+			.recordPhoto(request.getRecord_photo())
 			.build();
 		DetailPlanRecordReadUseCase.FindDetailPlanRecordResult result = detailPlanRecordOperationUseCase.updateRecord(
 			command);

--- a/gotbetter/src/main/java/pcrc/gotbetter/detail_plan_record/ui/request_body/DetailPlanRecordRequest.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/detail_plan_record/ui/request_body/DetailPlanRecordRequest.java
@@ -1,13 +1,16 @@
 package pcrc.gotbetter.detail_plan_record.ui.request_body;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
 @ToString
-@NoArgsConstructor
+@AllArgsConstructor
 public class DetailPlanRecordRequest {
 
 	@NotBlank
@@ -15,4 +18,7 @@ public class DetailPlanRecordRequest {
 
 	@NotBlank
 	private String record_body;
+
+	@NotNull
+	private MultipartFile record_photo;
 }


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #175 
<br/>

## ⚙️ 변경 사항 

인증 업로드 및 업데이트 request data 형식 변경

- 사진과 텍스트 분리하여 받는 부분을 하나의 dto로 수정

<br/>

## 💦 변경한 이유

- react native에서는 multipart와 json 따로 보내줄 수 없어 하나의 dto 사용으로 변경

<br/>

## 💻 테스트 사항

- postman

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
