### PR TITLE
[feat] 관리자 권한 방 참여자 강퇴 기능 구현

### DIFF
--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/service/ParticipantOperationUseCase.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/service/ParticipantOperationUseCase.java
@@ -15,6 +15,8 @@ public interface ParticipantOperationUseCase {
 
 	void rejectJoinRoom(UserRoomAcceptedCommand command);
 
+	void deleteParticipant(Long participantId);
+
 	@EqualsAndHashCode(callSuper = false)
 	@Builder
 	@Getter

--- a/gotbetter/src/main/java/pcrc/gotbetter/participant/ui/controller/ParticipantController.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/participant/ui/controller/ParticipantController.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -123,5 +124,14 @@ public class ParticipantController {
 		Integer refund = participantReadUseCase.getMyRefund(participant_id);
 
 		return ResponseEntity.ok(RefundView.builder().refund(refund).build());
+	}
+
+	@DeleteMapping(value = "/{participant_id}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void deleteParticipant(@PathVariable(value = "participant_id") Long participantId) {
+
+		log.info("\"DELETE PARTICIPANT\"");
+
+		participantOperationUseCase.deleteParticipant(participantId);
 	}
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/room/data_access/entity/Room.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/room/data_access/entity/Room.java
@@ -110,4 +110,8 @@ public class Room extends BaseTimeEntity {
 		this.roomCategory = roomCategory;
 		this.rule = rule;
 	}
+
+	public void decreaseCurrentUserNum() {
+		this.currentUserNum -= 1;
+	}
 }


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #195 
<br/>

## ⚙️ 변경 사항 

관리자 권한 방 참여자 강퇴 기능 구현

- 참여자 정보를 삭제하고
- 방 정보 중 참여 인원을 수정
- 방 정보 중 전체 참가비 수정 없이 그대로 놔두고
- 방장을 강퇴 불가능하게 구현함

<br/>

## 💦 변경한 이유

- 관리자 권한 방 참여자 강퇴 기능 추가

<br/>

## 💻 테스트 사항

- 어떻게 테스트를 실행했는지 작성

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
