### PR TITLE
[bug] 소셜 로그인 시 비어있는 userSet 데이터 지정하여 저장

### DIFF
--- a/gotbetter/src/main/java/pcrc/gotbetter/user/login_method/jwt/service/CustomUserDetailService.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/login_method/jwt/service/CustomUserDetailService.java
@@ -7,21 +7,17 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import pcrc.gotbetter.user.data_access.entity.User;
-import pcrc.gotbetter.user.data_access.entity.UserSet;
 import pcrc.gotbetter.user.data_access.repository.UserRepository;
-import pcrc.gotbetter.user.data_access.repository.UserSetRepository;
 import pcrc.gotbetter.user.login_method.oauth.UserPrincipal;
 
 @Service
 public class CustomUserDetailService implements UserDetailsService {
 
 	private final UserRepository userRepository;
-	private final UserSetRepository userSetRepository;
 
 	@Autowired
-	public CustomUserDetailService(UserRepository userRepository, UserSetRepository userSetRepository) {
+	public CustomUserDetailService(UserRepository userRepository) {
 		this.userRepository = userRepository;
-		this.userSetRepository = userSetRepository;
 	}
 
 	@Override
@@ -30,10 +26,7 @@ public class CustomUserDetailService implements UserDetailsService {
 		User user = userRepository.findByUserId(Long.valueOf(userId)).orElseThrow(() -> {
 			throw new UsernameNotFoundException("Not existed user.");
 		});
-		UserSet userSet = userSetRepository.findByUserId(Long.valueOf(userId));
-		if (userSet == null) {
-			throw new UsernameNotFoundException("Not existed user.");
-		}
-		return UserPrincipal.create(user, userSet);
+
+		return UserPrincipal.create(user);
 	}
 }

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/login_method/oauth/UserPrincipal.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/login_method/oauth/UserPrincipal.java
@@ -17,7 +17,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import pcrc.gotbetter.user.data_access.entity.User;
-import pcrc.gotbetter.user.data_access.entity.UserSet;
 import pcrc.gotbetter.user.login_method.login_type.RoleType;
 
 @Getter
@@ -87,10 +86,10 @@ public class UserPrincipal implements OAuth2User, UserDetails, OidcUser {
 		return null;
 	}
 
-	public static UserPrincipal create(User user, UserSet userSet) {
+	public static UserPrincipal create(User user) {
 		return new UserPrincipal(
 			user.getUserId().toString(),
-			userSet.getPassword(),
+			"",
 			// user.getProviderType(),
 			RoleType.USER,
 			Collections.singleton(new SimpleGrantedAuthority(RoleType.USER.getCode()))

--- a/gotbetter/src/main/java/pcrc/gotbetter/user/ui/controller/OAuthController.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/user/ui/controller/OAuthController.java
@@ -32,6 +32,8 @@ public class OAuthController {
 		@RequestParam(name = "provider") String provider,
 		@Valid @RequestBody OAuthRequest request
 	) {
+
+		log.info("\"OAUTH LOGIN\"");
 		provider = provider.toUpperCase();
 
 		if (!ProviderType.contains(provider)) {


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #231 
<br/>

## ⚙️ 변경 사항 

소셜 로그인 시 비어있는 userSet 데이터 지정하여 저장

- 처음 소셜 로그인할 때 userSet 데이터 지정해서 저장
- jwt 토큰을 포함한 요청이 들어왔을 때 불필요한 userSet 데이터 사용 삭제

<br/>

## 💦 변경한 이유

- 소셜 로그인 했을 때  userSet에 존재하지 않는 데이터에 접근하는 에러가 발생

<br/>

## 💻 테스트 사항

- 어떻게 테스트를 실행했는지 작성

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
