### PR TITLE
[bug] countCompleteTrue 메소드에서 컨텍스트 삭제하는 코드 제거

### DIFF
--- a/gotbetter/src/main/java/pcrc/gotbetter/detail_plan/data_access/repository/DetailPlanRepositoryImpl.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/detail_plan/data_access/repository/DetailPlanRepositoryImpl.java
@@ -10,7 +10,6 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
 import pcrc.gotbetter.detail_plan.data_access.dto.DetailPlanDto;
 import pcrc.gotbetter.detail_plan.data_access.entity.DetailPlan;
 
@@ -35,14 +34,18 @@ public class DetailPlanRepositoryImpl implements DetailPlanQueryRepository {
 
 	@Override
 	public HashMap<String, Long> countCompleteTrue(Long planId) {
-		Query query = em.createQuery(
-			"SELECT count(*) as size, count(if(p.complete=true, p.complete, null))" +
-				" FROM DetailPlan p WHERE p.planId = " + planId);
-		Object[] object = (Object[])query.getResultList().get(0);
+		Long size = (long)queryFactory.selectFrom(detailPlan)
+			.where(detailPlan.planId.eq(planId))
+			.fetch().size();
+
+		Long completeCount = (long)queryFactory.selectFrom(detailPlan)
+			.where(detailPlan.planId.eq(planId).and(detailPlan.complete.isTrue()))
+			.fetch().size();
+
 		HashMap<String, Long> result = new HashMap<>();
-		result.put("size", (Long)object[0]);
-		result.put("completeCount", (Long)object[1]);
-		em.clear();
+
+		result.put("size", size);
+		result.put("completeCount", completeCount);
 		return result;
 	}
 

--- a/gotbetter/src/main/java/pcrc/gotbetter/setting/common/TaskResult.java
+++ b/gotbetter/src/main/java/pcrc/gotbetter/setting/common/TaskResult.java
@@ -19,20 +19,20 @@ import pcrc.gotbetter.plan.data_access.repository.PlanRepository;
 import pcrc.gotbetter.room.data_access.entity.Room;
 import pcrc.gotbetter.setting.http_api.GotBetterException;
 import pcrc.gotbetter.setting.http_api.MessageType;
-import pcrc.gotbetter.user.login_method.login_type.RoleType;
 
 @Component
 public class TaskResult {
 
 	private final ParticipantRepository participantRepository;
-
 	private final PlanRepository planRepository;
-
 	private final DetailPlanRepository detailPlanRepository;
 
 	@Autowired
-	public TaskResult(ParticipantRepository participantRepository, PlanRepository planRepository,
-		DetailPlanRepository detailPlanRepository) {
+	public TaskResult(
+		ParticipantRepository participantRepository,
+		PlanRepository planRepository,
+		DetailPlanRepository detailPlanRepository
+	) {
 		this.participantRepository = participantRepository;
 		this.planRepository = planRepository;
 		this.detailPlanRepository = detailPlanRepository;
@@ -112,7 +112,6 @@ public class TaskResult {
 					refund = 0;
 				}
 				participant.updateRefund(refund);
-				participant.updateById(RoleType.SERVER.getCode());
 			}
 			participantRepository.saveAll(participants);
 			rank += percentMap.get(key).size();


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #241 
<br/>

## ⚙️ 변경 사항 

countCompleteTrue 메소드에서 컨텍스트 삭제하는 코드 제거

- em.clear() 코드 삭제

jpa 네이티브 쿼리를 querydsl 쿼리로 수정

- 코드의 일관성

<br/>

## 💦 변경한 이유

- em.clear()는 영속성 컨텍스트를 초기화하여 영속성 컨텍스트의 모든 엔티티를 준영속 상태로 만든다.
- 준영속 상태에서는 데이터를 수정해도 데이터베이스 변경이 불가능하다.
- 만약 em.clear() 메서드를 호출했을 때, 해당 트랜잭션 내에서 이전에 변경한 내용이 있다면 모두 롤백되는 효과가 있다.
- 따라서 DetailPlanRecordService 클래스의 계획 인증 삭제 메소드 안의 delete 쿼리가 제대로 동작을 하지 않아 오류가 발생한 것이다.

<br/>

## 💻 테스트 사항

- 어떻게 테스트를 실행했는지 작성

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
